### PR TITLE
refactor: use subtests instead of TestXXX_YyY naming pattern

### DIFF
--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -8,64 +8,66 @@ import (
 	"github.com/spf13/viper"
 )
 
-func TestInitConfig_IgnoresCurrentDirectory(t *testing.T) {
-	// Create a wildgecu.yaml in a temp dir that should NOT be picked up.
-	tmpDir := t.TempDir()
+func TestInitConfig(t *testing.T) {
+	t.Run("IgnoresCurrentDirectory", func(t *testing.T) {
+		// Create a wildgecu.yaml in a temp dir that should NOT be picked up.
+		tmpDir := t.TempDir()
 
-	cfgContent := []byte("gemini_api_key: from-local-dir\nmodel: local-model\n")
-	if err := os.WriteFile(filepath.Join(tmpDir, "wildgecu.yaml"), cfgContent, 0o644); err != nil {
-		t.Fatal(err)
-	}
+		cfgContent := []byte("gemini_api_key: from-local-dir\nmodel: local-model\n")
+		if err := os.WriteFile(filepath.Join(tmpDir, "wildgecu.yaml"), cfgContent, 0o644); err != nil {
+			t.Fatal(err)
+		}
 
-	origDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { os.Chdir(origDir) })
+		origDir, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { os.Chdir(origDir) })
 
-	if err := os.Chdir(tmpDir); err != nil {
-		t.Fatal(err)
-	}
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
 
-	// Reset viper and global state, then run initConfig.
-	viper.Reset()
-	cfgFile = ""
-	initConfig()
+		// Reset viper and global state, then run initConfig.
+		viper.Reset()
+		cfgFile = ""
+		initConfig()
 
-	// The local directory config should NOT have been loaded.
-	if got := viper.GetString("gemini_api_key"); got == "from-local-dir" {
-		t.Error("initConfig loaded config from current directory; expected it to only use global home")
-	}
+		// The local directory config should NOT have been loaded.
+		if got := viper.GetString("gemini_api_key"); got == "from-local-dir" {
+			t.Error("initConfig loaded config from current directory; expected it to only use global home")
+		}
 
-	if got := viper.GetString("model"); got == "local-model" {
-		t.Error("initConfig loaded model from current directory; expected it to only use global home")
-	}
-}
+		if got := viper.GetString("model"); got == "local-model" {
+			t.Error("initConfig loaded model from current directory; expected it to only use global home")
+		}
+	})
 
-func TestInitConfig_LoadsFromGlobalHome(t *testing.T) {
-	// Override HOME so GlobalHome() creates config in a temp dir.
-	tmpHome := t.TempDir()
-	t.Setenv("HOME", tmpHome)
+	t.Run("LoadsFromGlobalHome", func(t *testing.T) {
+		// Override HOME so GlobalHome() creates config in a temp dir.
+		tmpHome := t.TempDir()
+		t.Setenv("HOME", tmpHome)
 
-	globalDir := filepath.Join(tmpHome, ".wildgecu")
-	if err := os.MkdirAll(globalDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
+		globalDir := filepath.Join(tmpHome, ".wildgecu")
+		if err := os.MkdirAll(globalDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
 
-	cfgContent := []byte("gemini_api_key: from-global-home\nmodel: global-model\n")
-	if err := os.WriteFile(filepath.Join(globalDir, "wildgecu.yaml"), cfgContent, 0o644); err != nil {
-		t.Fatal(err)
-	}
+		cfgContent := []byte("gemini_api_key: from-global-home\nmodel: global-model\n")
+		if err := os.WriteFile(filepath.Join(globalDir, "wildgecu.yaml"), cfgContent, 0o644); err != nil {
+			t.Fatal(err)
+		}
 
-	viper.Reset()
-	cfgFile = ""
-	initConfig()
+		viper.Reset()
+		cfgFile = ""
+		initConfig()
 
-	if got := viper.GetString("gemini_api_key"); got != "from-global-home" {
-		t.Errorf("gemini_api_key = %q, want %q", got, "from-global-home")
-	}
+		if got := viper.GetString("gemini_api_key"); got != "from-global-home" {
+			t.Errorf("gemini_api_key = %q, want %q", got, "from-global-home")
+		}
 
-	if got := viper.GetString("model"); got != "global-model" {
-		t.Errorf("model = %q, want %q", got, "global-model")
-	}
+		if got := viper.GetString("model"); got != "global-model" {
+			t.Errorf("model = %q, want %q", got, "global-model")
+		}
+	})
 }

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -9,179 +9,179 @@ import (
 	"wildgecu/pkg/provider"
 )
 
-// --- LoadSoul ---
+func TestLoadSoul(t *testing.T) {
+	t.Run("Exists", func(t *testing.T) {
+		h := home.NewTmpHome(t)
+		if err := h.Soul().Write("I am a helpful agent."); err != nil {
+			t.Fatalf("setup: %v", err)
+		}
 
-func TestLoadSoul_Exists(t *testing.T) {
-	h := home.NewTmpHome(t)
-	if err := h.Soul().Write("I am a helpful agent."); err != nil {
-		t.Fatalf("setup: %v", err)
-	}
+		content, err := LoadSoul(h)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if content != "I am a helpful agent." {
+			t.Fatalf("got %q, want %q", content, "I am a helpful agent.")
+		}
+	})
 
-	content, err := LoadSoul(h)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if content != "I am a helpful agent." {
-		t.Fatalf("got %q, want %q", content, "I am a helpful agent.")
-	}
+	t.Run("NotExists", func(t *testing.T) {
+		h := home.NewTmpHome(t)
+
+		content, err := LoadSoul(h)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if content != "" {
+			t.Fatalf("got %q, want empty string", content)
+		}
+	})
 }
 
-func TestLoadSoul_NotExists(t *testing.T) {
-	h := home.NewTmpHome(t)
+func TestLoadMemory(t *testing.T) {
+	t.Run("Exists", func(t *testing.T) {
+		h := home.NewTmpHome(t)
+		if err := h.Memory().Write("some memory"); err != nil {
+			t.Fatalf("setup: %v", err)
+		}
 
-	content, err := LoadSoul(h)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if content != "" {
-		t.Fatalf("got %q, want empty string", content)
-	}
+		content, err := LoadMemory(h)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if content != "some memory" {
+			t.Fatalf("got %q, want %q", content, "some memory")
+		}
+	})
+
+	t.Run("NotExists", func(t *testing.T) {
+		h := home.NewTmpHome(t)
+
+		content, err := LoadMemory(h)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if content != "" {
+			t.Fatalf("got %q, want empty string", content)
+		}
+	})
 }
 
-// --- LoadMemory ---
+func TestBootstrapConfig(t *testing.T) {
+	t.Run("WritesSoul", func(t *testing.T) {
+		h := home.NewTmpHome(t)
+		var soulContent string
 
-func TestLoadMemory_Exists(t *testing.T) {
-	h := home.NewTmpHome(t)
-	if err := h.Memory().Write("some memory"); err != nil {
-		t.Fatalf("setup: %v", err)
-	}
+		cfg := BootstrapConfig(context.Background(), nil, h, &soulContent)
 
-	content, err := LoadMemory(h)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if content != "some memory" {
-		t.Fatalf("got %q, want %q", content, "some memory")
-	}
+		tc := provider.ToolCall{
+			ID:   "1",
+			Name: "write_soul",
+			Args: map[string]any{"content": "My soul content"},
+		}
+
+		result, err := cfg.Executor(context.Background(), tc)
+		if !errors.Is(err, provider.ErrDone) {
+			t.Fatalf("expected provider.ErrDone, got %v", err)
+		}
+		if result != `{"status":"ok"}` {
+			t.Fatalf("unexpected result: %s", result)
+		}
+		if soulContent != "My soul content" {
+			t.Fatalf("soulContent = %q, want %q", soulContent, "My soul content")
+		}
+		data, err := h.Soul().Get()
+		if err != nil {
+			t.Fatalf("SOUL.md not persisted: %v", err)
+		}
+		if data != "My soul content" {
+			t.Fatalf("persisted content = %q, want %q", data, "My soul content")
+		}
+	})
+
+	t.Run("EmptyContent", func(t *testing.T) {
+		h := home.NewTmpHome(t)
+		var soulContent string
+
+		cfg := BootstrapConfig(context.Background(), nil, h, &soulContent)
+
+		tc := provider.ToolCall{
+			ID:   "1",
+			Name: "write_soul",
+			Args: map[string]any{"content": ""},
+		}
+
+		_, err := cfg.Executor(context.Background(), tc)
+		if err == nil {
+			t.Fatal("expected error for empty content")
+		}
+	})
+
+	t.Run("UnknownTool", func(t *testing.T) {
+		h := home.NewTmpHome(t)
+		var soulContent string
+
+		cfg := BootstrapConfig(context.Background(), nil, h, &soulContent)
+
+		tc := provider.ToolCall{
+			ID:   "1",
+			Name: "unknown_tool",
+			Args: map[string]any{},
+		}
+
+		result, err := cfg.Executor(context.Background(), tc)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result != `{"error": "unknown tool: unknown_tool"}` {
+			t.Fatalf("unexpected result: %s", result)
+		}
+	})
 }
 
-func TestLoadMemory_NotExists(t *testing.T) {
-	h := home.NewTmpHome(t)
+func TestBuildSystemPrompt(t *testing.T) {
+	t.Run("WithSoul", func(t *testing.T) {
+		ws := home.NewTmpHome(t)
 
-	content, err := LoadMemory(h)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if content != "" {
-		t.Fatalf("got %q, want empty string", content)
-	}
-}
+		prompt := BuildSystemPrompt(ws, "I am a test soul.", "")
+		if !contains(prompt, "# Agent Soul") {
+			t.Fatal("expected soul section in prompt")
+		}
+		if !contains(prompt, "I am a test soul.") {
+			t.Fatal("expected soul content in prompt")
+		}
+	})
 
-// --- BootstrapConfig ---
+	t.Run("WithUserPrefs", func(t *testing.T) {
+		ws := home.NewTmpHome(t)
+		if err := ws.User().Write("Prefer Go."); err != nil {
+			t.Fatalf("setup: %v", err)
+		}
 
-func TestBootstrapConfig_WritesSoul(t *testing.T) {
-	h := home.NewTmpHome(t)
-	var soulContent string
+		prompt := BuildSystemPrompt(ws, "soul", "")
+		if !contains(prompt, "# User Preferences") {
+			t.Fatal("expected user preferences section in prompt")
+		}
+		if !contains(prompt, "Prefer Go.") {
+			t.Fatal("expected user prefs content in prompt")
+		}
+	})
 
-	cfg := BootstrapConfig(context.Background(), nil, h, &soulContent)
+	t.Run("NoUserPrefs", func(t *testing.T) {
+		ws := home.NewTmpHome(t)
 
-	tc := provider.ToolCall{
-		ID:   "1",
-		Name: "write_soul",
-		Args: map[string]any{"content": "My soul content"},
-	}
+		prompt := BuildSystemPrompt(ws, "soul", "")
+		if contains(prompt, "# User Preferences") {
+			t.Fatal("did not expect user preferences section in prompt")
+		}
+	})
 
-	result, err := cfg.Executor(context.Background(), tc)
-	if !errors.Is(err, provider.ErrDone) {
-		t.Fatalf("expected provider.ErrDone, got %v", err)
-	}
-	if result != `{"status":"ok"}` {
-		t.Fatalf("unexpected result: %s", result)
-	}
-	if soulContent != "My soul content" {
-		t.Fatalf("soulContent = %q, want %q", soulContent, "My soul content")
-	}
-	data, err := h.Soul().Get()
-	if err != nil {
-		t.Fatalf("SOUL.md not persisted: %v", err)
-	}
-	if data != "My soul content" {
-		t.Fatalf("persisted content = %q, want %q", data, "My soul content")
-	}
-}
-
-func TestBootstrapConfig_EmptyContent(t *testing.T) {
-	h := home.NewTmpHome(t)
-	var soulContent string
-
-	cfg := BootstrapConfig(context.Background(), nil, h, &soulContent)
-
-	tc := provider.ToolCall{
-		ID:   "1",
-		Name: "write_soul",
-		Args: map[string]any{"content": ""},
-	}
-
-	_, err := cfg.Executor(context.Background(), tc)
-	if err == nil {
-		t.Fatal("expected error for empty content")
-	}
-}
-
-func TestBootstrapConfig_UnknownTool(t *testing.T) {
-	h := home.NewTmpHome(t)
-	var soulContent string
-
-	cfg := BootstrapConfig(context.Background(), nil, h, &soulContent)
-
-	tc := provider.ToolCall{
-		ID:   "1",
-		Name: "unknown_tool",
-		Args: map[string]any{},
-	}
-
-	result, err := cfg.Executor(context.Background(), tc)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if result != `{"error": "unknown tool: unknown_tool"}` {
-		t.Fatalf("unexpected result: %s", result)
-	}
-}
-
-// --- BuildSystemPrompt ---
-
-func TestBuildSystemPrompt_WithSoul(t *testing.T) {
-	ws := home.NewTmpHome(t)
-
-	prompt := BuildSystemPrompt(ws, "I am a test soul.", "")
-	if !contains(prompt, "# Agent Soul") {
-		t.Fatal("expected soul section in prompt")
-	}
-	if !contains(prompt, "I am a test soul.") {
-		t.Fatal("expected soul content in prompt")
-	}
-}
-
-func TestBuildSystemPrompt_WithUserPrefs(t *testing.T) {
-	ws := home.NewTmpHome(t)
-	if err := ws.User().Write("Prefer Go."); err != nil {
-		t.Fatalf("setup: %v", err)
-	}
-
-	prompt := BuildSystemPrompt(ws, "soul", "")
-	if !contains(prompt, "# User Preferences") {
-		t.Fatal("expected user preferences section in prompt")
-	}
-	if !contains(prompt, "Prefer Go.") {
-		t.Fatal("expected user prefs content in prompt")
-	}
-}
-
-func TestBuildSystemPrompt_NoUserPrefs(t *testing.T) {
-	ws := home.NewTmpHome(t)
-
-	prompt := BuildSystemPrompt(ws, "soul", "")
-	if contains(prompt, "# User Preferences") {
-		t.Fatal("did not expect user preferences section in prompt")
-	}
-}
-
-func TestBuildSystemPrompt_NilWorkspace(t *testing.T) {
-	prompt := BuildSystemPrompt(nil, "soul", "")
-	if contains(prompt, "# User Preferences") {
-		t.Fatal("did not expect user preferences section with nil workspace")
-	}
+	t.Run("NilWorkspace", func(t *testing.T) {
+		prompt := BuildSystemPrompt(nil, "soul", "")
+		if contains(prompt, "# User Preferences") {
+			t.Fatal("did not expect user preferences section with nil workspace")
+		}
+	})
 }
 
 func contains(s, substr string) bool {

--- a/pkg/home/home_test.go
+++ b/pkg/home/home_test.go
@@ -9,25 +9,27 @@ import (
 	"wildgecu/x/file"
 )
 
-func TestNew_creates_directory_and_Dir_returns_path(t *testing.T) {
-	dir := filepath.Join(t.TempDir(), "subdir")
+func TestNew(t *testing.T) {
+	t.Run("creates directory and Dir returns path", func(t *testing.T) {
+		dir := filepath.Join(t.TempDir(), "subdir")
 
-	h, err := New(dir)
-	if err != nil {
-		t.Fatalf("New(%q): %v", dir, err)
-	}
+		h, err := New(dir)
+		if err != nil {
+			t.Fatalf("New(%q): %v", dir, err)
+		}
 
-	if h.Dir() != dir {
-		t.Errorf("Dir() = %q, want %q", h.Dir(), dir)
-	}
+		if h.Dir() != dir {
+			t.Errorf("Dir() = %q, want %q", h.Dir(), dir)
+		}
 
-	info, err := os.Stat(dir)
-	if err != nil {
-		t.Fatalf("directory not created: %v", err)
-	}
-	if !info.IsDir() {
-		t.Fatal("path exists but is not a directory")
-	}
+		info, err := os.Stat(dir)
+		if err != nil {
+			t.Fatalf("directory not created: %v", err)
+		}
+		if !info.IsDir() {
+			t.Fatal("path exists but is not a directory")
+		}
+	})
 }
 
 func TestNewTmpHome(t *testing.T) {
@@ -44,54 +46,56 @@ func TestNewTmpHome(t *testing.T) {
 	}
 }
 
-func TestIdentityFiles_return_empty_when_missing(t *testing.T) {
-	h := NewTmpHome(t)
+func TestIdentityFiles(t *testing.T) {
+	t.Run("return empty when missing", func(t *testing.T) {
+		h := NewTmpHome(t)
 
-	for _, tc := range []struct {
-		name string
-		f    file.File
-	}{
-		{"Soul", h.Soul()},
-		{"Memory", h.Memory()},
-		{"User", h.User()},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			content, err := tc.f.Get()
-			if err != nil {
-				t.Fatalf("Get() error: %v", err)
-			}
-			if content != "" {
-				t.Errorf("Get() = %q, want empty string", content)
-			}
-		})
-	}
-}
+		for _, tc := range []struct {
+			name string
+			f    file.File
+		}{
+			{"Soul", h.Soul()},
+			{"Memory", h.Memory()},
+			{"User", h.User()},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				content, err := tc.f.Get()
+				if err != nil {
+					t.Fatalf("Get() error: %v", err)
+				}
+				if content != "" {
+					t.Errorf("Get() = %q, want empty string", content)
+				}
+			})
+		}
+	})
 
-func TestIdentityFiles_round_trip(t *testing.T) {
-	h := NewTmpHome(t)
+	t.Run("round trip", func(t *testing.T) {
+		h := NewTmpHome(t)
 
-	for _, tc := range []struct {
-		name string
-		f    file.File
-	}{
-		{"Soul", h.Soul()},
-		{"Memory", h.Memory()},
-		{"User", h.User()},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			want := "hello from " + tc.name
-			if err := tc.f.Write(want); err != nil {
-				t.Fatalf("Write() error: %v", err)
-			}
-			got, err := tc.f.Get()
-			if err != nil {
-				t.Fatalf("Get() error: %v", err)
-			}
-			if got != want {
-				t.Errorf("Get() = %q, want %q", got, want)
-			}
-		})
-	}
+		for _, tc := range []struct {
+			name string
+			f    file.File
+		}{
+			{"Soul", h.Soul()},
+			{"Memory", h.Memory()},
+			{"User", h.User()},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				want := "hello from " + tc.name
+				if err := tc.f.Write(want); err != nil {
+					t.Fatalf("Write() error: %v", err)
+				}
+				got, err := tc.f.Get()
+				if err != nil {
+					t.Fatalf("Get() error: %v", err)
+				}
+				if got != want {
+					t.Errorf("Get() = %q, want %q", got, want)
+				}
+			})
+		}
+	})
 }
 
 func TestDirectoryAccessors(t *testing.T) {

--- a/pkg/provider/agent_test.go
+++ b/pkg/provider/agent_test.go
@@ -14,212 +14,214 @@ func noopLogger() *debug.Logger {
 	return &debug.Logger{}
 }
 
-func TestExecuteToolsParallel_RunsConcurrently(t *testing.T) {
-	var running atomic.Int32
-	var maxConcurrent atomic.Int32
+func TestExecuteToolsParallel(t *testing.T) {
+	t.Run("RunsConcurrently", func(t *testing.T) {
+		var running atomic.Int32
+		var maxConcurrent atomic.Int32
 
-	toolCalls := []ToolCall{
-		{ID: "tool_a", Name: "tool_a", Args: map[string]any{"x": 1}},
-		{ID: "tool_b", Name: "tool_b", Args: map[string]any{"x": 2}},
-		{ID: "tool_c", Name: "tool_c", Args: map[string]any{"x": 3}},
-	}
+		toolCalls := []ToolCall{
+			{ID: "tool_a", Name: "tool_a", Args: map[string]any{"x": 1}},
+			{ID: "tool_b", Name: "tool_b", Args: map[string]any{"x": 2}},
+			{ID: "tool_c", Name: "tool_c", Args: map[string]any{"x": 3}},
+		}
 
-	executor := func(ctx context.Context, tc ToolCall) (string, error) {
-		cur := running.Add(1)
-		// Track max concurrency
-		for {
-			old := maxConcurrent.Load()
-			if cur <= old || maxConcurrent.CompareAndSwap(old, cur) {
-				break
+		executor := func(ctx context.Context, tc ToolCall) (string, error) {
+			cur := running.Add(1)
+			// Track max concurrency
+			for {
+				old := maxConcurrent.Load()
+				if cur <= old || maxConcurrent.CompareAndSwap(old, cur) {
+					break
+				}
+			}
+			time.Sleep(50 * time.Millisecond)
+			running.Add(-1)
+			return "ok:" + tc.Name, nil
+		}
+
+		msgs, err := executeToolsParallel(context.Background(), toolCalls, executor, nil, noopLogger())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if maxConcurrent.Load() < 2 {
+			t.Errorf("expected concurrent execution, max concurrency was %d", maxConcurrent.Load())
+		}
+
+		if len(msgs) != 3 {
+			t.Fatalf("expected 3 messages, got %d", len(msgs))
+		}
+
+		// Results must be in the same order as toolCalls
+		for i, tc := range toolCalls {
+			if msgs[i].Role != RoleTool {
+				t.Errorf("msgs[%d].Role = %q, want %q", i, msgs[i].Role, RoleTool)
+			}
+			if msgs[i].Content != "ok:"+tc.Name {
+				t.Errorf("msgs[%d].Content = %q, want %q", i, msgs[i].Content, "ok:"+tc.Name)
+			}
+			if msgs[i].ToolCallID != tc.Name {
+				t.Errorf("msgs[%d].ToolCallID = %q, want %q", i, msgs[i].ToolCallID, tc.Name)
 			}
 		}
-		time.Sleep(50 * time.Millisecond)
-		running.Add(-1)
-		return "ok:" + tc.Name, nil
-	}
+	})
 
-	msgs, err := executeToolsParallel(context.Background(), toolCalls, executor, nil, noopLogger())
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	if maxConcurrent.Load() < 2 {
-		t.Errorf("expected concurrent execution, max concurrency was %d", maxConcurrent.Load())
-	}
-
-	if len(msgs) != 3 {
-		t.Fatalf("expected 3 messages, got %d", len(msgs))
-	}
-
-	// Results must be in the same order as toolCalls
-	for i, tc := range toolCalls {
-		if msgs[i].Role != RoleTool {
-			t.Errorf("msgs[%d].Role = %q, want %q", i, msgs[i].Role, RoleTool)
+	t.Run("PreservesOrder", func(t *testing.T) {
+		toolCalls := []ToolCall{
+			{ID: "slow", Name: "slow", Args: map[string]any{}},
+			{ID: "fast", Name: "fast", Args: map[string]any{}},
 		}
-		if msgs[i].Content != "ok:"+tc.Name {
-			t.Errorf("msgs[%d].Content = %q, want %q", i, msgs[i].Content, "ok:"+tc.Name)
+
+		executor := func(ctx context.Context, tc ToolCall) (string, error) {
+			if tc.Name == "slow" {
+				time.Sleep(80 * time.Millisecond)
+			}
+			return tc.Name + "_result", nil
 		}
-		if msgs[i].ToolCallID != tc.Name {
-			t.Errorf("msgs[%d].ToolCallID = %q, want %q", i, msgs[i].ToolCallID, tc.Name)
+
+		msgs, err := executeToolsParallel(context.Background(), toolCalls, executor, nil, noopLogger())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
 		}
-	}
-}
 
-func TestExecuteToolsParallel_PreservesOrder(t *testing.T) {
-	toolCalls := []ToolCall{
-		{ID: "slow", Name: "slow", Args: map[string]any{}},
-		{ID: "fast", Name: "fast", Args: map[string]any{}},
-	}
-
-	executor := func(ctx context.Context, tc ToolCall) (string, error) {
-		if tc.Name == "slow" {
-			time.Sleep(80 * time.Millisecond)
+		if msgs[0].Content != "slow_result" {
+			t.Errorf("msgs[0] should be slow_result, got %q", msgs[0].Content)
 		}
-		return tc.Name + "_result", nil
-	}
-
-	msgs, err := executeToolsParallel(context.Background(), toolCalls, executor, nil, noopLogger())
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	if msgs[0].Content != "slow_result" {
-		t.Errorf("msgs[0] should be slow_result, got %q", msgs[0].Content)
-	}
-	if msgs[1].Content != "fast_result" {
-		t.Errorf("msgs[1] should be fast_result, got %q", msgs[1].Content)
-	}
-}
-
-func TestExecuteToolsParallel_ErrDone(t *testing.T) {
-	toolCalls := []ToolCall{
-		{ID: "normal", Name: "normal", Args: map[string]any{}},
-		{ID: "done", Name: "done", Args: map[string]any{}},
-	}
-
-	executor := func(ctx context.Context, tc ToolCall) (string, error) {
-		if tc.Name == "done" {
-			return "finished", ErrDone
+		if msgs[1].Content != "fast_result" {
+			t.Errorf("msgs[1] should be fast_result, got %q", msgs[1].Content)
 		}
-		return "ok", nil
-	}
+	})
 
-	msgs, err := executeToolsParallel(context.Background(), toolCalls, executor, nil, noopLogger())
-	if !errors.Is(err, ErrDone) {
-		t.Fatalf("expected ErrDone, got %v", err)
-	}
+	t.Run("ErrDone", func(t *testing.T) {
+		toolCalls := []ToolCall{
+			{ID: "normal", Name: "normal", Args: map[string]any{}},
+			{ID: "done", Name: "done", Args: map[string]any{}},
+		}
 
-	// All messages should still be returned
-	if len(msgs) != 2 {
-		t.Fatalf("expected 2 messages, got %d", len(msgs))
-	}
-	if msgs[0].Content != "ok" {
-		t.Errorf("msgs[0].Content = %q, want %q", msgs[0].Content, "ok")
-	}
-	if msgs[1].Content != "finished" {
-		t.Errorf("msgs[1].Content = %q, want %q", msgs[1].Content, "finished")
-	}
-}
-
-func TestExecuteToolsParallel_ErrorFormatsMessage(t *testing.T) {
-	toolCalls := []ToolCall{
-		{ID: "failing", Name: "failing", Args: map[string]any{}},
-	}
-
-	executor := func(ctx context.Context, tc ToolCall) (string, error) {
-		return "", errors.New("something broke")
-	}
-
-	msgs, err := executeToolsParallel(context.Background(), toolCalls, executor, nil, noopLogger())
-	if err != nil {
-		t.Fatalf("non-sentinel errors should not propagate, got %v", err)
-	}
-
-	if msgs[0].Content != "Error: something broke" {
-		t.Errorf("expected formatted error, got %q", msgs[0].Content)
-	}
-}
-
-func TestExecuteToolsParallel_CallbackInvoked(t *testing.T) {
-	toolCalls := []ToolCall{
-		{ID: "a", Name: "a", Args: map[string]any{}},
-		{ID: "b", Name: "b", Args: map[string]any{}},
-	}
-
-	var callbackCount atomic.Int32
-	callback := func(tc ToolCall) {
-		callbackCount.Add(1)
-	}
-
-	executor := func(ctx context.Context, tc ToolCall) (string, error) {
-		return "ok", nil
-	}
-
-	_, err := executeToolsParallel(context.Background(), toolCalls, executor, callback, noopLogger())
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	if callbackCount.Load() != 2 {
-		t.Errorf("expected callback called 2 times, got %d", callbackCount.Load())
-	}
-}
-
-func TestExecuteToolsParallel_EmptyToolCalls(t *testing.T) {
-	executor := func(ctx context.Context, tc ToolCall) (string, error) {
-		t.Fatal("executor should not be called")
-		return "", nil
-	}
-
-	msgs, err := executeToolsParallel(context.Background(), nil, executor, nil, noopLogger())
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if len(msgs) != 0 {
-		t.Errorf("expected 0 messages, got %d", len(msgs))
-	}
-}
-
-func TestExecuteToolsParallel_SingleToolCall(t *testing.T) {
-	toolCalls := []ToolCall{
-		{ID: "only", Name: "only", Args: map[string]any{"key": "val"}},
-	}
-
-	executor := func(ctx context.Context, tc ToolCall) (string, error) {
-		return "single_result", nil
-	}
-
-	msgs, err := executeToolsParallel(context.Background(), toolCalls, executor, nil, noopLogger())
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if len(msgs) != 1 {
-		t.Fatalf("expected 1 message, got %d", len(msgs))
-	}
-	if msgs[0].Content != "single_result" {
-		t.Errorf("got %q, want %q", msgs[0].Content, "single_result")
-	}
-}
-
-func TestExecuteToolsParallel_MultipleErrDone(t *testing.T) {
-	toolCalls := []ToolCall{
-		{ID: "done1", Name: "done1", Args: map[string]any{}},
-		{ID: "done2", Name: "done2", Args: map[string]any{}},
-		{ID: "normal", Name: "normal", Args: map[string]any{}},
-	}
-
-	executor := func(ctx context.Context, tc ToolCall) (string, error) {
-		if tc.Name == "normal" {
+		executor := func(ctx context.Context, tc ToolCall) (string, error) {
+			if tc.Name == "done" {
+				return "finished", ErrDone
+			}
 			return "ok", nil
 		}
-		return "done", ErrDone
-	}
 
-	msgs, err := executeToolsParallel(context.Background(), toolCalls, executor, nil, noopLogger())
-	if !errors.Is(err, ErrDone) {
-		t.Fatalf("expected ErrDone, got %v", err)
-	}
-	if len(msgs) != 3 {
-		t.Fatalf("expected 3 messages, got %d", len(msgs))
-	}
+		msgs, err := executeToolsParallel(context.Background(), toolCalls, executor, nil, noopLogger())
+		if !errors.Is(err, ErrDone) {
+			t.Fatalf("expected ErrDone, got %v", err)
+		}
+
+		// All messages should still be returned
+		if len(msgs) != 2 {
+			t.Fatalf("expected 2 messages, got %d", len(msgs))
+		}
+		if msgs[0].Content != "ok" {
+			t.Errorf("msgs[0].Content = %q, want %q", msgs[0].Content, "ok")
+		}
+		if msgs[1].Content != "finished" {
+			t.Errorf("msgs[1].Content = %q, want %q", msgs[1].Content, "finished")
+		}
+	})
+
+	t.Run("ErrorFormatsMessage", func(t *testing.T) {
+		toolCalls := []ToolCall{
+			{ID: "failing", Name: "failing", Args: map[string]any{}},
+		}
+
+		executor := func(ctx context.Context, tc ToolCall) (string, error) {
+			return "", errors.New("something broke")
+		}
+
+		msgs, err := executeToolsParallel(context.Background(), toolCalls, executor, nil, noopLogger())
+		if err != nil {
+			t.Fatalf("non-sentinel errors should not propagate, got %v", err)
+		}
+
+		if msgs[0].Content != "Error: something broke" {
+			t.Errorf("expected formatted error, got %q", msgs[0].Content)
+		}
+	})
+
+	t.Run("CallbackInvoked", func(t *testing.T) {
+		toolCalls := []ToolCall{
+			{ID: "a", Name: "a", Args: map[string]any{}},
+			{ID: "b", Name: "b", Args: map[string]any{}},
+		}
+
+		var callbackCount atomic.Int32
+		callback := func(tc ToolCall) {
+			callbackCount.Add(1)
+		}
+
+		executor := func(ctx context.Context, tc ToolCall) (string, error) {
+			return "ok", nil
+		}
+
+		_, err := executeToolsParallel(context.Background(), toolCalls, executor, callback, noopLogger())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if callbackCount.Load() != 2 {
+			t.Errorf("expected callback called 2 times, got %d", callbackCount.Load())
+		}
+	})
+
+	t.Run("EmptyToolCalls", func(t *testing.T) {
+		executor := func(ctx context.Context, tc ToolCall) (string, error) {
+			t.Fatal("executor should not be called")
+			return "", nil
+		}
+
+		msgs, err := executeToolsParallel(context.Background(), nil, executor, nil, noopLogger())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(msgs) != 0 {
+			t.Errorf("expected 0 messages, got %d", len(msgs))
+		}
+	})
+
+	t.Run("SingleToolCall", func(t *testing.T) {
+		toolCalls := []ToolCall{
+			{ID: "only", Name: "only", Args: map[string]any{"key": "val"}},
+		}
+
+		executor := func(ctx context.Context, tc ToolCall) (string, error) {
+			return "single_result", nil
+		}
+
+		msgs, err := executeToolsParallel(context.Background(), toolCalls, executor, nil, noopLogger())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(msgs) != 1 {
+			t.Fatalf("expected 1 message, got %d", len(msgs))
+		}
+		if msgs[0].Content != "single_result" {
+			t.Errorf("got %q, want %q", msgs[0].Content, "single_result")
+		}
+	})
+
+	t.Run("MultipleErrDone", func(t *testing.T) {
+		toolCalls := []ToolCall{
+			{ID: "done1", Name: "done1", Args: map[string]any{}},
+			{ID: "done2", Name: "done2", Args: map[string]any{}},
+			{ID: "normal", Name: "normal", Args: map[string]any{}},
+		}
+
+		executor := func(ctx context.Context, tc ToolCall) (string, error) {
+			if tc.Name == "normal" {
+				return "ok", nil
+			}
+			return "done", ErrDone
+		}
+
+		msgs, err := executeToolsParallel(context.Background(), toolCalls, executor, nil, noopLogger())
+		if !errors.Is(err, ErrDone) {
+			t.Fatalf("expected ErrDone, got %v", err)
+		}
+		if len(msgs) != 3 {
+			t.Fatalf("expected 3 messages, got %d", len(msgs))
+		}
+	})
 }

--- a/pkg/provider/tool/tool_test.go
+++ b/pkg/provider/tool/tool_test.go
@@ -12,116 +12,118 @@ import (
 
 // --- Schema generation ---
 
-func TestGenerateSchema_SimpleStruct(t *testing.T) {
-	type Input struct {
-		Name string `json:"name" description:"The user name"`
-		Age  int    `json:"age" description:"The user age"`
-	}
+func TestGenerateSchema(t *testing.T) {
+	t.Run("SimpleStruct", func(t *testing.T) {
+		type Input struct {
+			Name string `json:"name" description:"The user name"`
+			Age  int    `json:"age" description:"The user age"`
+		}
 
-	schema := generateSchema(reflect.TypeOf(Input{}))
+		schema := generateSchema(reflect.TypeOf(Input{}))
 
-	props, ok := schema["properties"].(map[string]any)
-	if !ok {
-		t.Fatal("expected properties map")
-	}
-	if len(props) != 2 {
-		t.Fatalf("expected 2 properties, got %d", len(props))
-	}
+		props, ok := schema["properties"].(map[string]any)
+		if !ok {
+			t.Fatal("expected properties map")
+		}
+		if len(props) != 2 {
+			t.Fatalf("expected 2 properties, got %d", len(props))
+		}
 
-	nameProp := props["name"].(map[string]any)
-	if nameProp["type"] != "string" {
-		t.Fatalf("name type = %v, want string", nameProp["type"])
-	}
-	if nameProp["description"] != "The user name" {
-		t.Fatalf("name description = %v", nameProp["description"])
-	}
+		nameProp := props["name"].(map[string]any)
+		if nameProp["type"] != "string" {
+			t.Fatalf("name type = %v, want string", nameProp["type"])
+		}
+		if nameProp["description"] != "The user name" {
+			t.Fatalf("name description = %v", nameProp["description"])
+		}
 
-	ageProp := props["age"].(map[string]any)
-	if ageProp["type"] != "number" {
-		t.Fatalf("age type = %v, want number", ageProp["type"])
-	}
+		ageProp := props["age"].(map[string]any)
+		if ageProp["type"] != "number" {
+			t.Fatalf("age type = %v, want number", ageProp["type"])
+		}
 
-	required := schema["required"].([]any)
-	if len(required) != 2 {
-		t.Fatalf("expected 2 required, got %d", len(required))
-	}
-}
+		required := schema["required"].([]any)
+		if len(required) != 2 {
+			t.Fatalf("expected 2 required, got %d", len(required))
+		}
+	})
 
-func TestGenerateSchema_Omitempty(t *testing.T) {
-	type Input struct {
-		Name     string `json:"name"`
-		Optional string `json:"optional,omitempty"`
-	}
+	t.Run("Omitempty", func(t *testing.T) {
+		type Input struct {
+			Name     string `json:"name"`
+			Optional string `json:"optional,omitempty"`
+		}
 
-	schema := generateSchema(reflect.TypeOf(Input{}))
+		schema := generateSchema(reflect.TypeOf(Input{}))
 
-	required := schema["required"].([]any)
-	if len(required) != 1 {
-		t.Fatalf("expected 1 required, got %d", len(required))
-	}
-	if required[0] != "name" {
-		t.Fatalf("required[0] = %v, want name", required[0])
-	}
-}
+		required := schema["required"].([]any)
+		if len(required) != 1 {
+			t.Fatalf("expected 1 required, got %d", len(required))
+		}
+		if required[0] != "name" {
+			t.Fatalf("required[0] = %v, want name", required[0])
+		}
+	})
 
-func TestGenerateSchema_SkipDash(t *testing.T) {
-	type Input struct {
-		Name    string `json:"name"`
-		Skipped string `json:"-"`
-	}
+	t.Run("SkipDash", func(t *testing.T) {
+		type Input struct {
+			Name    string `json:"name"`
+			Skipped string `json:"-"`
+		}
 
-	schema := generateSchema(reflect.TypeOf(Input{}))
-	props := schema["properties"].(map[string]any)
-	if len(props) != 1 {
-		t.Fatalf("expected 1 property, got %d", len(props))
-	}
-}
+		schema := generateSchema(reflect.TypeOf(Input{}))
+		props := schema["properties"].(map[string]any)
+		if len(props) != 1 {
+			t.Fatalf("expected 1 property, got %d", len(props))
+		}
+	})
 
-func TestGenerateSchema_NestedStruct(t *testing.T) {
-	type Address struct {
-		City string `json:"city"`
-	}
-	type Input struct {
-		Addr Address `json:"addr"`
-	}
+	t.Run("NestedStruct", func(t *testing.T) {
+		type Address struct {
+			City string `json:"city"`
+		}
+		type Input struct {
+			Addr Address `json:"addr"`
+		}
 
-	schema := generateSchema(reflect.TypeOf(Input{}))
-	props := schema["properties"].(map[string]any)
-	addrProp := props["addr"].(map[string]any)
-	innerProps := addrProp["properties"].(map[string]any)
-	if _, ok := innerProps["city"]; !ok {
-		t.Fatal("expected nested city property")
-	}
-}
+		schema := generateSchema(reflect.TypeOf(Input{}))
+		props := schema["properties"].(map[string]any)
+		addrProp := props["addr"].(map[string]any)
+		innerProps := addrProp["properties"].(map[string]any)
+		if _, ok := innerProps["city"]; !ok {
+			t.Fatal("expected nested city property")
+		}
+	})
 
-func TestGenerateSchema_Slice(t *testing.T) {
-	type Input struct {
-		Tags []string `json:"tags"`
-	}
+	t.Run("Slice", func(t *testing.T) {
+		type Input struct {
+			Tags []string `json:"tags"`
+		}
 
-	schema := generateSchema(reflect.TypeOf(Input{}))
-	props := schema["properties"].(map[string]any)
-	tagsProp := props["tags"].(map[string]any)
-	if tagsProp["type"] != "array" {
-		t.Fatalf("tags type = %v, want array", tagsProp["type"])
-	}
-	items := tagsProp["items"].(map[string]any)
-	if items["type"] != "string" {
-		t.Fatalf("items type = %v, want string", items["type"])
-	}
-}
+		schema := generateSchema(reflect.TypeOf(Input{}))
+		props := schema["properties"].(map[string]any)
+		tagsProp := props["tags"].(map[string]any)
+		if tagsProp["type"] != "array" {
+			t.Fatalf("tags type = %v, want array", tagsProp["type"])
+		}
+		items := tagsProp["items"].(map[string]any)
+		if items["type"] != "string" {
+			t.Fatalf("items type = %v, want string", items["type"])
+		}
+	})
 
-func TestGenerateSchema_Bool(t *testing.T) {
-	type Input struct {
-		Verbose bool `json:"verbose"`
-	}
+	t.Run("Bool", func(t *testing.T) {
+		type Input struct {
+			Verbose bool `json:"verbose"`
+		}
 
-	schema := generateSchema(reflect.TypeOf(Input{}))
-	props := schema["properties"].(map[string]any)
-	verbProp := props["verbose"].(map[string]any)
-	if verbProp["type"] != "boolean" {
-		t.Fatalf("verbose type = %v, want boolean", verbProp["type"])
-	}
+		schema := generateSchema(reflect.TypeOf(Input{}))
+		props := schema["properties"].(map[string]any)
+		verbProp := props["verbose"].(map[string]any)
+		if verbProp["type"] != "boolean" {
+			t.Fatalf("verbose type = %v, want boolean", verbProp["type"])
+		}
+	})
 }
 
 // --- Tool execution ---
@@ -134,108 +136,112 @@ type EchoOutput struct {
 	Echo string `json:"echo"`
 }
 
-func TestNewTool_Definition(t *testing.T) {
-	echoTool := NewTool("echo", "Echoes the message",
-		func(ctx context.Context, in EchoInput) (EchoOutput, error) {
-			return EchoOutput{Echo: in.Message}, nil
-		},
-	)
+func TestNewTool(t *testing.T) {
+	t.Run("Definition", func(t *testing.T) {
+		echoTool := NewTool("echo", "Echoes the message",
+			func(ctx context.Context, in EchoInput) (EchoOutput, error) {
+				return EchoOutput{Echo: in.Message}, nil
+			},
+		)
 
-	def := echoTool.Definition()
-	if def.Name != "echo" {
-		t.Fatalf("name = %q, want echo", def.Name)
-	}
-	if def.Description != "Echoes the message" {
-		t.Fatalf("description = %q", def.Description)
-	}
+		def := echoTool.Definition()
+		if def.Name != "echo" {
+			t.Fatalf("name = %q, want echo", def.Name)
+		}
+		if def.Description != "Echoes the message" {
+			t.Fatalf("description = %q", def.Description)
+		}
 
-	props := def.Parameters["properties"].(map[string]any)
-	msgProp := props["message"].(map[string]any)
-	if msgProp["type"] != "string" {
-		t.Fatalf("message type = %v", msgProp["type"])
-	}
-}
+		props := def.Parameters["properties"].(map[string]any)
+		msgProp := props["message"].(map[string]any)
+		if msgProp["type"] != "string" {
+			t.Fatalf("message type = %v", msgProp["type"])
+		}
+	})
 
-func TestNewTool_Execute(t *testing.T) {
-	echoTool := NewTool("echo", "Echoes the message",
-		func(ctx context.Context, in EchoInput) (EchoOutput, error) {
-			return EchoOutput{Echo: in.Message}, nil
-		},
-	)
+	t.Run("Execute", func(t *testing.T) {
+		echoTool := NewTool("echo", "Echoes the message",
+			func(ctx context.Context, in EchoInput) (EchoOutput, error) {
+				return EchoOutput{Echo: in.Message}, nil
+			},
+		)
 
-	result, err := echoTool.Execute(context.Background(), map[string]any{"message": "hello"})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+		result, err := echoTool.Execute(context.Background(), map[string]any{"message": "hello"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 
-	var out EchoOutput
-	if err := json.Unmarshal([]byte(result), &out); err != nil {
-		t.Fatalf("unmarshal result: %v", err)
-	}
-	if out.Echo != "hello" {
-		t.Fatalf("echo = %q, want hello", out.Echo)
-	}
-}
+		var out EchoOutput
+		if err := json.Unmarshal([]byte(result), &out); err != nil {
+			t.Fatalf("unmarshal result: %v", err)
+		}
+		if out.Echo != "hello" {
+			t.Fatalf("echo = %q, want hello", out.Echo)
+		}
+	})
 
-func TestNewTool_ExecuteWithError(t *testing.T) {
-	failTool := NewTool("fail", "Always fails",
-		func(ctx context.Context, in EchoInput) (EchoOutput, error) {
-			return EchoOutput{}, provider.ErrDone
-		},
-	)
+	t.Run("ExecuteWithError", func(t *testing.T) {
+		failTool := NewTool("fail", "Always fails",
+			func(ctx context.Context, in EchoInput) (EchoOutput, error) {
+				return EchoOutput{}, provider.ErrDone
+			},
+		)
 
-	_, err := failTool.Execute(context.Background(), map[string]any{"message": "hello"})
-	if !errors.Is(err, provider.ErrDone) {
-		t.Fatalf("expected ErrDone, got %v", err)
-	}
+		_, err := failTool.Execute(context.Background(), map[string]any{"message": "hello"})
+		if !errors.Is(err, provider.ErrDone) {
+			t.Fatalf("expected ErrDone, got %v", err)
+		}
+	})
 }
 
 // --- Registry ---
 
-func TestRegistry_ToolsAndExecutor(t *testing.T) {
-	echoTool := NewTool("echo", "Echoes the message",
-		func(ctx context.Context, in EchoInput) (EchoOutput, error) {
-			return EchoOutput{Echo: in.Message}, nil
-		},
-	)
+func TestRegistry(t *testing.T) {
+	t.Run("ToolsAndExecutor", func(t *testing.T) {
+		echoTool := NewTool("echo", "Echoes the message",
+			func(ctx context.Context, in EchoInput) (EchoOutput, error) {
+				return EchoOutput{Echo: in.Message}, nil
+			},
+		)
 
-	reg := NewRegistry(echoTool)
+		reg := NewRegistry(echoTool)
 
-	tools := reg.Tools()
-	if len(tools) != 1 {
-		t.Fatalf("expected 1 tool, got %d", len(tools))
-	}
-	if tools[0].Name != "echo" {
-		t.Fatalf("tool name = %q", tools[0].Name)
-	}
+		tools := reg.Tools()
+		if len(tools) != 1 {
+			t.Fatalf("expected 1 tool, got %d", len(tools))
+		}
+		if tools[0].Name != "echo" {
+			t.Fatalf("tool name = %q", tools[0].Name)
+		}
 
-	executor := reg.Executor()
-	result, err := executor(context.Background(), provider.ToolCall{
-		Name: "echo",
-		Args: map[string]any{"message": "world"},
+		executor := reg.Executor()
+		result, err := executor(context.Background(), provider.ToolCall{
+			Name: "echo",
+			Args: map[string]any{"message": "world"},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		var out EchoOutput
+		if err := json.Unmarshal([]byte(result), &out); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if out.Echo != "world" {
+			t.Fatalf("echo = %q, want world", out.Echo)
+		}
 	})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
 
-	var out EchoOutput
-	if err := json.Unmarshal([]byte(result), &out); err != nil {
-		t.Fatalf("unmarshal: %v", err)
-	}
-	if out.Echo != "world" {
-		t.Fatalf("echo = %q, want world", out.Echo)
-	}
-}
+	t.Run("UnknownTool", func(t *testing.T) {
+		reg := NewRegistry()
+		executor := reg.Executor()
 
-func TestRegistry_UnknownTool(t *testing.T) {
-	reg := NewRegistry()
-	executor := reg.Executor()
-
-	result, err := executor(context.Background(), provider.ToolCall{Name: "nope", Args: map[string]any{}})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if result != `{"error": "unknown tool: nope"}` {
-		t.Fatalf("unexpected result: %s", result)
-	}
+		result, err := executor(context.Background(), provider.ToolCall{Name: "nope", Args: map[string]any{}})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result != `{"error": "unknown tool: nope"}` {
+			t.Fatalf("unexpected result: %s", result)
+		}
+	})
 }

--- a/x/file/fsfile_test.go
+++ b/x/file/fsfile_test.go
@@ -6,13 +6,15 @@ import (
 )
 
 func TestFSFile(t *testing.T) {
-	dir := t.TempDir()
-	f := NewFSFile(filepath.Join(dir, "test.txt"))
-	RunFileSpec(t, f)
-}
+	t.Run("basic", func(t *testing.T) {
+		dir := t.TempDir()
+		f := NewFSFile(filepath.Join(dir, "test.txt"))
+		RunFileSpec(t, f)
+	})
 
-func TestFSFile_ReplaceMissing(t *testing.T) {
-	dir := t.TempDir()
-	f := NewFSFile(filepath.Join(dir, "nonexistent.txt"))
-	RunFileSpecReplaceMissing(t, f)
+	t.Run("ReplaceMissing", func(t *testing.T) {
+		dir := t.TempDir()
+		f := NewFSFile(filepath.Join(dir, "nonexistent.txt"))
+		RunFileSpecReplaceMissing(t, f)
+	})
 }


### PR DESCRIPTION
Convert all test files to use t.Run() subtests grouped under a single
parent test function, following the project's coding conventions.

https://claude.ai/code/session_01KBPoX8trpPaUkEDG3kg3NT