### PR TITLE
feat: add slash commands with autocomplete for TUI and Telegram

### DIFF
--- a/pkg/chat/telegram/commands.go
+++ b/pkg/chat/telegram/commands.go
@@ -1,0 +1,56 @@
+package telegram
+
+import (
+	"sort"
+
+	"wildgecu/pkg/command"
+
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
+)
+
+const (
+	maxCommands      = 100
+	maxDescriptionLen = 256
+	minDescriptionLen = 3
+)
+
+// buildBotCommands converts command entries into Telegram BotCommands, applying
+// Telegram's limits: max 100 commands and 3–256 char descriptions.
+func buildBotCommands(entries []command.Entry) []tgbotapi.BotCommand {
+	limit := len(entries)
+	if limit > maxCommands {
+		limit = maxCommands
+	}
+
+	cmds := make([]tgbotapi.BotCommand, 0, limit)
+	for _, e := range entries[:limit] {
+		desc := e.Description
+		if len(desc) > maxDescriptionLen {
+			desc = desc[:maxDescriptionLen-3] + "..."
+		}
+		if len(desc) < minDescriptionLen {
+			desc += "..."[:minDescriptionLen-len(desc)]
+		}
+		cmds = append(cmds, tgbotapi.BotCommand{
+			Command:     e.Name,
+			Description: desc,
+		})
+	}
+	sort.Slice(cmds, func(i, j int) bool {
+		return cmds[i].Command < cmds[j].Command
+	})
+	return cmds
+}
+
+// SyncCommands registers the current command list with Telegram's native
+// autocomplete via setMyCommands.
+func (b *Bridge) SyncCommands() error {
+	var entries []command.Entry
+	if b.commands != nil {
+		entries = b.commands.List()
+	}
+	cmds := buildBotCommands(entries)
+	cfg := tgbotapi.NewSetMyCommands(cmds...)
+	_, err := b.bot.Request(cfg)
+	return err
+}

--- a/pkg/chat/telegram/commands_test.go
+++ b/pkg/chat/telegram/commands_test.go
@@ -1,0 +1,296 @@
+package telegram
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+
+	"wildgecu/pkg/command"
+	"wildgecu/pkg/skill"
+
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
+)
+
+func TestBuildBotCommands(t *testing.T) {
+	t.Run("basic conversion", func(t *testing.T) {
+		entries := []command.Entry{
+			{Name: "help", Description: "Show help"},
+			{Name: "status", Description: "Show status"},
+		}
+		cmds := buildBotCommands(entries)
+		if len(cmds) != 2 {
+			t.Fatalf("expected 2 commands, got %d", len(cmds))
+		}
+		if cmds[0].Command != "help" || cmds[0].Description != "Show help" {
+			t.Errorf("unexpected first command: %+v", cmds[0])
+		}
+		if cmds[1].Command != "status" || cmds[1].Description != "Show status" {
+			t.Errorf("unexpected second command: %+v", cmds[1])
+		}
+	})
+
+	t.Run("empty list", func(t *testing.T) {
+		cmds := buildBotCommands(nil)
+		if len(cmds) != 0 {
+			t.Errorf("expected 0 commands, got %d", len(cmds))
+		}
+	})
+
+	t.Run("truncates description to 256 chars", func(t *testing.T) {
+		long := strings.Repeat("a", 300)
+		entries := []command.Entry{{Name: "test", Description: long}}
+		cmds := buildBotCommands(entries)
+		if len(cmds) != 1 {
+			t.Fatalf("expected 1 command, got %d", len(cmds))
+		}
+		if len(cmds[0].Description) > 256 {
+			t.Errorf("description length %d exceeds 256", len(cmds[0].Description))
+		}
+		// Should end with ellipsis to indicate truncation.
+		if !strings.HasSuffix(cmds[0].Description, "...") {
+			t.Errorf("truncated description should end with '...', got %q", cmds[0].Description[250:])
+		}
+	})
+
+	t.Run("limits to 100 commands", func(t *testing.T) {
+		entries := make([]command.Entry, 120)
+		for i := range entries {
+			entries[i] = command.Entry{Name: "cmd" + strings.Repeat("x", 2), Description: "desc"}
+		}
+		cmds := buildBotCommands(entries)
+		if len(cmds) > 100 {
+			t.Errorf("expected at most 100 commands, got %d", len(cmds))
+		}
+	})
+
+	t.Run("empty description gets default", func(t *testing.T) {
+		entries := []command.Entry{{Name: "test", Description: ""}}
+		cmds := buildBotCommands(entries)
+		if len(cmds) != 1 {
+			t.Fatalf("expected 1 command, got %d", len(cmds))
+		}
+		if len(cmds[0].Description) < 3 {
+			t.Errorf("description too short for Telegram (min 3): %q", cmds[0].Description)
+		}
+	})
+
+	t.Run("short description padded to minimum 3 chars", func(t *testing.T) {
+		entries := []command.Entry{{Name: "x", Description: "ab"}}
+		cmds := buildBotCommands(entries)
+		if len(cmds) != 1 {
+			t.Fatalf("expected 1 command, got %d", len(cmds))
+		}
+		if len(cmds[0].Description) < 3 {
+			t.Errorf("description too short for Telegram (min 3): %q", cmds[0].Description)
+		}
+	})
+
+	t.Run("description exactly 256 chars not truncated", func(t *testing.T) {
+		exact := strings.Repeat("b", 256)
+		entries := []command.Entry{{Name: "test", Description: exact}}
+		cmds := buildBotCommands(entries)
+		if cmds[0].Description != exact {
+			t.Error("description of exactly 256 chars should not be modified")
+		}
+	})
+}
+
+// mockBot records Request calls for testing.
+type mockBot struct {
+	mu       sync.Mutex
+	requests []tgbotapi.Chattable
+}
+
+func (m *mockBot) Send(c tgbotapi.Chattable) (tgbotapi.Message, error) {
+	return tgbotapi.Message{}, nil
+}
+
+func (m *mockBot) Request(c tgbotapi.Chattable) (*tgbotapi.APIResponse, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.requests = append(m.requests, c)
+	return &tgbotapi.APIResponse{Ok: true}, nil
+}
+
+func (m *mockBot) GetUpdatesChan(config tgbotapi.UpdateConfig) tgbotapi.UpdatesChannel {
+	return make(tgbotapi.UpdatesChannel)
+}
+
+func (m *mockBot) StopReceivingUpdates() {}
+
+// stubSession implements SessionProvider for testing.
+type stubSession struct{}
+
+func (s *stubSession) CreateSession() string { return "test-session" }
+func (s *stubSession) RunTurnStreamRaw(_ context.Context, _, _ string, _ func(string), _ func(string, string), _ func(string)) (string, error) {
+	return "ok", nil
+}
+func (s *stubSession) RunSkillTurnStreamRaw(_ context.Context, _, _, _ string, _ func(string), _ func(string, string), _ func(string)) (string, error) {
+	return "ok", nil
+}
+func (s *stubSession) WelcomeText() string { return "welcome" }
+
+func newTestBridge(bot botAPI, registry *command.Registry) *Bridge {
+	return &Bridge{
+		bot:          bot,
+		sm:           &stubSession{},
+		commands:     registry,
+		chatSessions: make(map[int64]string),
+		logger:       slog.Default(),
+	}
+}
+
+func TestSyncCommands(t *testing.T) {
+	t.Run("sends commands at sync", func(t *testing.T) {
+		reg := command.NewRegistry("")
+		reg.Register(&stubCommand{name: "help", desc: "Show help"})
+		reg.Register(&stubCommand{name: "status", desc: "Show status"})
+
+		bot := &mockBot{}
+		b := newTestBridge(bot, reg)
+
+		if err := b.SyncCommands(); err != nil {
+			t.Fatalf("SyncCommands error: %v", err)
+		}
+
+		bot.mu.Lock()
+		defer bot.mu.Unlock()
+		if len(bot.requests) != 1 {
+			t.Fatalf("expected 1 request, got %d", len(bot.requests))
+		}
+		cfg, ok := bot.requests[0].(tgbotapi.SetMyCommandsConfig)
+		if !ok {
+			t.Fatalf("expected SetMyCommandsConfig, got %T", bot.requests[0])
+		}
+		if len(cfg.Commands) != 2 {
+			t.Errorf("expected 2 commands, got %d", len(cfg.Commands))
+		}
+	})
+
+	t.Run("nil registry does not error", func(t *testing.T) {
+		bot := &mockBot{}
+		b := newTestBridge(bot, nil)
+
+		if err := b.SyncCommands(); err != nil {
+			t.Fatalf("SyncCommands error: %v", err)
+		}
+
+		bot.mu.Lock()
+		defer bot.mu.Unlock()
+		if len(bot.requests) != 1 {
+			t.Fatalf("expected 1 request, got %d", len(bot.requests))
+		}
+		cfg := bot.requests[0].(tgbotapi.SetMyCommandsConfig)
+		if len(cfg.Commands) != 0 {
+			t.Errorf("expected 0 commands, got %d", len(cfg.Commands))
+		}
+	})
+
+	t.Run("includes skill commands", func(t *testing.T) {
+		dir := t.TempDir()
+		writeTestSkill(t, dir, "---\nname: deploy\ndescription: Deploy the app\n---\nDeploy instructions")
+
+		reg := command.NewRegistry(dir)
+		reg.Register(&stubCommand{name: "help", desc: "Show help"})
+
+		bot := &mockBot{}
+		b := newTestBridge(bot, reg)
+
+		if err := b.SyncCommands(); err != nil {
+			t.Fatalf("SyncCommands error: %v", err)
+		}
+
+		cfg := bot.requests[0].(tgbotapi.SetMyCommandsConfig)
+		if len(cfg.Commands) != 2 {
+			t.Fatalf("expected 2 commands (help + deploy), got %d", len(cfg.Commands))
+		}
+
+		names := map[string]bool{}
+		for _, c := range cfg.Commands {
+			names[c.Command] = true
+		}
+		if !names["help"] || !names["deploy"] {
+			t.Errorf("expected help and deploy commands, got %v", names)
+		}
+	})
+
+	t.Run("refreshes after skill added", func(t *testing.T) {
+		dir := t.TempDir()
+		reg := command.NewRegistry(dir)
+		reg.Register(&stubCommand{name: "help", desc: "Show help"})
+
+		bot := &mockBot{}
+		b := newTestBridge(bot, reg)
+
+		// Initial sync: only built-in "help".
+		if err := b.SyncCommands(); err != nil {
+			t.Fatalf("SyncCommands error: %v", err)
+		}
+		cfg := bot.requests[0].(tgbotapi.SetMyCommandsConfig)
+		if len(cfg.Commands) != 1 {
+			t.Fatalf("expected 1 command initially, got %d", len(cfg.Commands))
+		}
+
+		// Add a skill to disk.
+		writeTestSkill(t, dir, "---\nname: deploy\ndescription: Deploy the app\n---\nDeploy")
+
+		// Sync again: should now include the new skill.
+		if err := b.SyncCommands(); err != nil {
+			t.Fatalf("SyncCommands error: %v", err)
+		}
+		cfg = bot.requests[1].(tgbotapi.SetMyCommandsConfig)
+		if len(cfg.Commands) != 2 {
+			t.Fatalf("expected 2 commands after skill added, got %d", len(cfg.Commands))
+		}
+	})
+
+	t.Run("commands are sorted alphabetically", func(t *testing.T) {
+		reg := command.NewRegistry("")
+		reg.Register(&stubCommand{name: "zebra", desc: "Last command"})
+		reg.Register(&stubCommand{name: "alpha", desc: "First command"})
+
+		bot := &mockBot{}
+		b := newTestBridge(bot, reg)
+
+		if err := b.SyncCommands(); err != nil {
+			t.Fatalf("SyncCommands error: %v", err)
+		}
+
+		cfg := bot.requests[0].(tgbotapi.SetMyCommandsConfig)
+		if len(cfg.Commands) != 2 {
+			t.Fatalf("expected 2 commands, got %d", len(cfg.Commands))
+		}
+		if cfg.Commands[0].Command != "alpha" {
+			t.Errorf("expected first command to be 'alpha', got %q", cfg.Commands[0].Command)
+		}
+		if cfg.Commands[1].Command != "zebra" {
+			t.Errorf("expected second command to be 'zebra', got %q", cfg.Commands[1].Command)
+		}
+	})
+}
+
+// stubCommand is a simple Command for testing within the telegram package.
+type stubCommand struct {
+	name string
+	desc string
+}
+
+func (c *stubCommand) Name() string        { return c.name }
+func (c *stubCommand) Description() string { return c.desc }
+func (c *stubCommand) Execute(_ context.Context, _ string) (string, error) {
+	return "executed " + c.name, nil
+}
+
+// writeTestSkill creates a skill directory with a SKILL.md file for testing.
+func writeTestSkill(t *testing.T, dir, data string) {
+	t.Helper()
+	s, err := skill.Parse([]byte(data))
+	if err != nil {
+		t.Fatalf("parse test skill: %v", err)
+	}
+	if err := skill.Save(dir, s); err != nil {
+		t.Fatalf("save test skill: %v", err)
+	}
+}

--- a/pkg/chat/telegram/telegram.go
+++ b/pkg/chat/telegram/telegram.go
@@ -18,7 +18,6 @@ import (
 // package does not depend on internal/daemon.
 type SessionProvider interface {
 	CreateSession() string // returns session ID
-	ResetSession(ctx context.Context, id string) (string, error)
 	RunTurnStreamRaw(ctx context.Context, id string, input string, onChunk func(string), onToolCall func(string, string), onInform func(string)) (string, error)
 	WelcomeText() string
 }
@@ -223,6 +222,7 @@ func (b *Bridge) updateSessionFromResult(chatID int64, result string) {
 	const prefix = "New session: "
 	idx := strings.Index(result, prefix)
 	if idx < 0 {
+		b.logger.Warn("updateSessionFromResult: could not parse new session ID from /clean result", "result", result)
 		return
 	}
 	newID := result[idx+len(prefix):]

--- a/pkg/chat/telegram/telegram.go
+++ b/pkg/chat/telegram/telegram.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 	"sync"
 	"time"
 
+	"wildgecu/pkg/command"
 	"wildgecu/pkg/telegram/auth"
 
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
@@ -24,6 +26,7 @@ type SessionProvider interface {
 type Bridge struct {
 	bot          *tgbotapi.BotAPI
 	sm           SessionProvider
+	commands     *command.Registry
 	auth         *auth.Store
 	chatSessions map[int64]string // chatID → session ID
 	mu           sync.RWMutex
@@ -31,8 +34,9 @@ type Bridge struct {
 }
 
 // New creates a new Telegram bridge using the given session provider.
-// authStore may be nil to allow all users.
-func New(token string, sm SessionProvider, authStore *auth.Store) (*Bridge, error) {
+// authStore may be nil to allow all users. commands may be nil to disable
+// slash command handling.
+func New(token string, sm SessionProvider, authStore *auth.Store, commands *command.Registry) (*Bridge, error) {
 	bot, err := tgbotapi.NewBotAPI(token)
 	if err != nil {
 		return nil, err
@@ -40,6 +44,7 @@ func New(token string, sm SessionProvider, authStore *auth.Store) (*Bridge, erro
 	return &Bridge{
 		bot:          bot,
 		sm:           sm,
+		commands:     commands,
 		auth:         authStore,
 		chatSessions: make(map[int64]string),
 		logger:       slog.Default(),
@@ -88,6 +93,31 @@ func (b *Bridge) handleMessage(ctx context.Context, msg *tgbotapi.Message) {
 	if msg.Text == "/start" {
 		b.sendMessages(chatID, b.sm.WelcomeText())
 		return
+	}
+
+	// Intercept slash commands and route to the command registry.
+	if b.commands != nil && strings.HasPrefix(msg.Text, "/") {
+		name, args := command.Parse(msg.Text)
+		if name != "" {
+			cmd := b.commands.Resolve(name)
+			if cmd == nil {
+				reply := tgbotapi.NewMessage(chatID, fmt.Sprintf("Unknown command: /%s", name))
+				if _, err := b.bot.Send(reply); err != nil {
+					b.logger.Error("telegram send error", "error", err)
+				}
+				return
+			}
+			result, err := cmd.Execute(ctx, args)
+			if err != nil {
+				reply := tgbotapi.NewMessage(chatID, fmt.Sprintf("Error: %v", err))
+				if _, err := b.bot.Send(reply); err != nil {
+					b.logger.Error("telegram send error", "error", err)
+				}
+				return
+			}
+			b.sendMessages(chatID, result)
+			return
+		}
 	}
 
 	sessionID := b.getOrCreateSession(chatID)

--- a/pkg/chat/telegram/telegram.go
+++ b/pkg/chat/telegram/telegram.go
@@ -18,6 +18,7 @@ import (
 // package does not depend on internal/daemon.
 type SessionProvider interface {
 	CreateSession() string // returns session ID
+	ResetSession(ctx context.Context, id string) (string, error)
 	RunTurnStreamRaw(ctx context.Context, id string, input string, onChunk func(string), onToolCall func(string, string), onInform func(string)) (string, error)
 	WelcomeText() string
 }
@@ -107,13 +108,20 @@ func (b *Bridge) handleMessage(ctx context.Context, msg *tgbotapi.Message) {
 				}
 				return
 			}
-			result, err := cmd.Execute(ctx, args)
+			// Inject session ID for session-aware commands like /clean.
+			sessionID := b.getOrCreateSession(chatID)
+			cmdCtx := command.WithSessionID(ctx, sessionID)
+			result, err := cmd.Execute(cmdCtx, args)
 			if err != nil {
 				reply := tgbotapi.NewMessage(chatID, fmt.Sprintf("Error: %v", err))
 				if _, err := b.bot.Send(reply); err != nil {
 					b.logger.Error("telegram send error", "error", err)
 				}
 				return
+			}
+			// If the command was /clean, update our chat→session mapping.
+			if name == "clean" {
+				b.updateSessionFromResult(chatID, result)
 			}
 			b.sendMessages(chatID, result)
 			return
@@ -206,6 +214,21 @@ func (h *turnHandler) onInform(message string) {
 	if _, err := h.bridge.bot.Request(tgbotapi.NewChatAction(h.chatID, tgbotapi.ChatTyping)); err != nil {
 		h.bridge.logger.Debug("telegram refresh chat action error", "error", err)
 	}
+}
+
+// updateSessionFromResult extracts the new session ID from a /clean result
+// and updates the chat→session mapping.
+func (b *Bridge) updateSessionFromResult(chatID int64, result string) {
+	// The result format is "Session reset. New session: <id>"
+	const prefix = "New session: "
+	idx := strings.Index(result, prefix)
+	if idx < 0 {
+		return
+	}
+	newID := result[idx+len(prefix):]
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.chatSessions[chatID] = newID
 }
 
 func (b *Bridge) getOrCreateSession(chatID int64) string {

--- a/pkg/chat/telegram/telegram.go
+++ b/pkg/chat/telegram/telegram.go
@@ -19,6 +19,7 @@ import (
 type SessionProvider interface {
 	CreateSession() string // returns session ID
 	RunTurnStreamRaw(ctx context.Context, id string, input string, onChunk func(string), onToolCall func(string, string), onInform func(string)) (string, error)
+	RunSkillTurnStreamRaw(ctx context.Context, id, skillContent, userInput string, onChunk func(string), onToolCall func(string, string), onInform func(string)) (string, error)
 	WelcomeText() string
 }
 
@@ -107,6 +108,11 @@ func (b *Bridge) handleMessage(ctx context.Context, msg *tgbotapi.Message) {
 				}
 				return
 			}
+			// Skill commands run a streaming LLM turn.
+			if runner, ok := cmd.(command.SkillRunner); ok {
+				b.handleSkillCommand(ctx, chatID, runner, args)
+				return
+			}
 			// Inject session ID for session-aware commands like /clean.
 			sessionID := b.getOrCreateSession(chatID)
 			cmdCtx := command.WithSessionID(ctx, sessionID)
@@ -168,6 +174,52 @@ func (b *Bridge) handleMessage(ctx context.Context, msg *tgbotapi.Message) {
 	}
 
 	// Long response: edit placeholder with first chunk, send rest as new messages
+	edit := tgbotapi.NewEditMessageText(chatID, sent.MessageID, finalContent[:4096])
+	if _, err := b.bot.Send(edit); err != nil {
+		b.logger.Error("telegram final edit error", "error", err)
+	}
+	b.sendMessages(chatID, finalContent[4096:])
+}
+
+func (b *Bridge) handleSkillCommand(ctx context.Context, chatID int64, runner command.SkillRunner, userInput string) {
+	sessionID := b.getOrCreateSession(chatID)
+
+	// Send typing indicator
+	if _, err := b.bot.Request(tgbotapi.NewChatAction(chatID, tgbotapi.ChatTyping)); err != nil {
+		b.logger.Error("telegram send chat action error", "error", err)
+	}
+
+	// Send placeholder message
+	placeholder := tgbotapi.NewMessage(chatID, "...")
+	sent, err := b.bot.Send(placeholder)
+	if err != nil {
+		b.logger.Error("telegram send placeholder error", "error", err)
+		return
+	}
+
+	h := &turnHandler{bridge: b, chatID: chatID, msgID: sent.MessageID}
+	finalContent, err := b.sm.RunSkillTurnStreamRaw(ctx, sessionID, runner.SkillContent(), userInput, h.onChunk, h.onToolCall, h.onInform)
+	if err != nil {
+		b.logger.Error("telegram skill command error", "error", err, "chat_id", chatID)
+		edit := tgbotapi.NewEditMessageText(chatID, sent.MessageID, fmt.Sprintf("Error: %v", err))
+		if _, err := b.bot.Send(edit); err != nil {
+			b.logger.Error("telegram edit error message failed", "error", err)
+		}
+		return
+	}
+
+	if finalContent == "" {
+		finalContent = "(empty response)"
+	}
+
+	if len(finalContent) <= 4096 {
+		edit := tgbotapi.NewEditMessageText(chatID, sent.MessageID, finalContent)
+		if _, err := b.bot.Send(edit); err != nil {
+			b.logger.Error("telegram final edit error", "error", err)
+		}
+		return
+	}
+
 	edit := tgbotapi.NewEditMessageText(chatID, sent.MessageID, finalContent[:4096])
 	if _, err := b.bot.Send(edit); err != nil {
 		b.logger.Error("telegram final edit error", "error", err)

--- a/pkg/chat/telegram/telegram.go
+++ b/pkg/chat/telegram/telegram.go
@@ -23,9 +23,19 @@ type SessionProvider interface {
 	WelcomeText() string
 }
 
+// botAPI abstracts the Telegram Bot API methods used by Bridge, enabling
+// testing without a real bot connection.
+type botAPI interface {
+	Send(c tgbotapi.Chattable) (tgbotapi.Message, error)
+	Request(c tgbotapi.Chattable) (*tgbotapi.APIResponse, error)
+	GetUpdatesChan(config tgbotapi.UpdateConfig) tgbotapi.UpdatesChannel
+	StopReceivingUpdates()
+}
+
 // Bridge connects a Telegram bot to the daemon's session manager.
 type Bridge struct {
-	bot          *tgbotapi.BotAPI
+	bot          botAPI
+	username     string
 	sm           SessionProvider
 	commands     *command.Registry
 	auth         *auth.Store
@@ -44,6 +54,7 @@ func New(token string, sm SessionProvider, authStore *auth.Store, commands *comm
 	}
 	return &Bridge{
 		bot:          bot,
+		username:     bot.Self.UserName,
 		sm:           sm,
 		commands:     commands,
 		auth:         authStore,
@@ -54,12 +65,16 @@ func New(token string, sm SessionProvider, authStore *auth.Store, commands *comm
 
 // Run starts the Telegram update loop. It blocks until ctx is cancelled.
 func (b *Bridge) Run(ctx context.Context) error {
+	if err := b.SyncCommands(); err != nil {
+		b.logger.Warn("failed to sync telegram commands at startup", "error", err)
+	}
+
 	u := tgbotapi.NewUpdate(0)
 	u.Timeout = 60
 
 	updates := b.bot.GetUpdatesChan(u)
 
-	b.logger.Info("telegram bot started", "username", b.bot.Self.UserName)
+	b.logger.Info("telegram bot started", "username", b.username)
 
 	for {
 		select {
@@ -75,6 +90,14 @@ func (b *Bridge) Run(ctx context.Context) error {
 }
 
 func (b *Bridge) handleMessage(ctx context.Context, msg *tgbotapi.Message) {
+	// Refresh Telegram's native command autocomplete after handling, in case
+	// the agent added or removed skills during this turn.
+	defer func() {
+		if err := b.SyncCommands(); err != nil {
+			b.logger.Debug("failed to sync telegram commands", "error", err)
+		}
+	}()
+
 	chatID := msg.Chat.ID
 
 	// Auth gate: block unauthenticated users before any processing.

--- a/pkg/chat/tui/autocomplete.go
+++ b/pkg/chat/tui/autocomplete.go
@@ -1,0 +1,84 @@
+package tui
+
+import (
+	"strings"
+
+	"wildgecu/pkg/daemon"
+)
+
+// Autocomplete filters and navigates a list of slash commands based on user input.
+type Autocomplete struct {
+	commands []daemon.CommandInfo
+	matches  []daemon.CommandInfo
+	selected int
+	visible  bool
+	lastPfx  string
+}
+
+// NewAutocomplete creates an Autocomplete with the given command list.
+func NewAutocomplete(commands []daemon.CommandInfo) *Autocomplete {
+	return &Autocomplete{commands: commands}
+}
+
+// Update recalculates the match list based on the current input text.
+func (a *Autocomplete) Update(input string) {
+	if !strings.HasPrefix(input, "/") || strings.Contains(input, " ") {
+		a.visible = false
+		a.matches = nil
+		a.selected = 0
+		a.lastPfx = ""
+		return
+	}
+
+	prefix := strings.ToLower(input[1:]) // strip leading "/"
+	if prefix != a.lastPfx {
+		a.selected = 0
+		a.lastPfx = prefix
+	}
+
+	a.matches = nil
+	for _, cmd := range a.commands {
+		if strings.HasPrefix(strings.ToLower(cmd.Name), prefix) {
+			a.matches = append(a.matches, cmd)
+		}
+	}
+
+	a.visible = len(a.matches) > 0
+	if a.selected >= len(a.matches) {
+		a.selected = 0
+	}
+}
+
+// Visible returns whether the dropdown should be shown.
+func (a *Autocomplete) Visible() bool { return a.visible }
+
+// Matches returns the current filtered command list.
+func (a *Autocomplete) Matches() []daemon.CommandInfo { return a.matches }
+
+// Selected returns the index of the highlighted item.
+func (a *Autocomplete) Selected() int { return a.selected }
+
+// MoveDown moves the selection down, wrapping around.
+func (a *Autocomplete) MoveDown() {
+	if len(a.matches) == 0 {
+		return
+	}
+	a.selected = (a.selected + 1) % len(a.matches)
+}
+
+// MoveUp moves the selection up, wrapping around.
+func (a *Autocomplete) MoveUp() {
+	if len(a.matches) == 0 {
+		return
+	}
+	a.selected = (a.selected - 1 + len(a.matches)) % len(a.matches)
+}
+
+// Complete returns the full command text for the selected item (e.g. "/help ").
+// Returns empty string if the autocomplete is not visible.
+func (a *Autocomplete) Complete() string {
+	if !a.visible || len(a.matches) == 0 {
+		return ""
+	}
+	return "/" + a.matches[a.selected].Name + " "
+}

--- a/pkg/chat/tui/autocomplete_test.go
+++ b/pkg/chat/tui/autocomplete_test.go
@@ -1,0 +1,168 @@
+package tui
+
+import (
+	"testing"
+
+	"wildgecu/pkg/daemon"
+)
+
+var testCommands = []daemon.CommandInfo{
+	{Name: "help", Description: "Show available commands"},
+	{Name: "status", Description: "Show session info"},
+	{Name: "clean", Description: "Reset current session"},
+	{Name: "search", Description: "Search the web"},
+}
+
+func TestAutocomplete(t *testing.T) {
+	t.Run("visible when input starts with slash and has no space", func(t *testing.T) {
+		ac := NewAutocomplete(testCommands)
+		ac.Update("/")
+		if !ac.Visible() {
+			t.Error("expected autocomplete to be visible for '/'")
+		}
+		ac.Update("/he")
+		if !ac.Visible() {
+			t.Error("expected autocomplete to be visible for '/he'")
+		}
+	})
+
+	t.Run("hidden when input is empty", func(t *testing.T) {
+		ac := NewAutocomplete(testCommands)
+		ac.Update("")
+		if ac.Visible() {
+			t.Error("expected autocomplete to be hidden for empty input")
+		}
+	})
+
+	t.Run("hidden when input does not start with slash", func(t *testing.T) {
+		ac := NewAutocomplete(testCommands)
+		ac.Update("hello")
+		if ac.Visible() {
+			t.Error("expected autocomplete to be hidden for 'hello'")
+		}
+	})
+
+	t.Run("hidden when input contains a space", func(t *testing.T) {
+		ac := NewAutocomplete(testCommands)
+		ac.Update("/help arg")
+		if ac.Visible() {
+			t.Error("expected autocomplete to be hidden when input has a space")
+		}
+	})
+
+	t.Run("filters commands by prefix case-insensitive", func(t *testing.T) {
+		ac := NewAutocomplete(testCommands)
+		ac.Update("/S")
+		matches := ac.Matches()
+		if len(matches) != 2 {
+			t.Fatalf("expected 2 matches for '/S', got %d: %+v", len(matches), matches)
+		}
+		// Should match "status" and "search"
+		names := map[string]bool{}
+		for _, m := range matches {
+			names[m.Name] = true
+		}
+		if !names["status"] || !names["search"] {
+			t.Errorf("expected status and search in matches, got %+v", matches)
+		}
+	})
+
+	t.Run("slash alone shows all commands", func(t *testing.T) {
+		ac := NewAutocomplete(testCommands)
+		ac.Update("/")
+		matches := ac.Matches()
+		if len(matches) != len(testCommands) {
+			t.Errorf("expected %d matches for '/', got %d", len(testCommands), len(matches))
+		}
+	})
+
+	t.Run("no matches hides autocomplete", func(t *testing.T) {
+		ac := NewAutocomplete(testCommands)
+		ac.Update("/zzz")
+		if ac.Visible() {
+			t.Error("expected autocomplete to be hidden when no commands match")
+		}
+	})
+
+	t.Run("selected index starts at zero", func(t *testing.T) {
+		ac := NewAutocomplete(testCommands)
+		ac.Update("/")
+		if ac.Selected() != 0 {
+			t.Errorf("expected selected index 0, got %d", ac.Selected())
+		}
+	})
+
+	t.Run("move down increments selected", func(t *testing.T) {
+		ac := NewAutocomplete(testCommands)
+		ac.Update("/")
+		ac.MoveDown()
+		if ac.Selected() != 1 {
+			t.Errorf("expected selected index 1, got %d", ac.Selected())
+		}
+	})
+
+	t.Run("move down wraps around", func(t *testing.T) {
+		ac := NewAutocomplete(testCommands)
+		ac.Update("/")
+		for range len(testCommands) {
+			ac.MoveDown()
+		}
+		if ac.Selected() != 0 {
+			t.Errorf("expected selected to wrap to 0, got %d", ac.Selected())
+		}
+	})
+
+	t.Run("move up wraps to last", func(t *testing.T) {
+		ac := NewAutocomplete(testCommands)
+		ac.Update("/")
+		ac.MoveUp()
+		want := len(testCommands) - 1
+		if ac.Selected() != want {
+			t.Errorf("expected selected to wrap to %d, got %d", want, ac.Selected())
+		}
+	})
+
+	t.Run("selection resets when filter changes", func(t *testing.T) {
+		ac := NewAutocomplete(testCommands)
+		ac.Update("/")
+		ac.MoveDown()
+		ac.MoveDown()
+		ac.Update("/s")
+		if ac.Selected() != 0 {
+			t.Errorf("expected selected to reset to 0 after filter change, got %d", ac.Selected())
+		}
+	})
+
+	t.Run("complete returns selected command with trailing space", func(t *testing.T) {
+		ac := NewAutocomplete(testCommands)
+		ac.Update("/")
+		result := ac.Complete()
+		if result == "" {
+			t.Fatal("expected non-empty completion")
+		}
+		// First match with trailing space.
+		expected := "/" + ac.Matches()[0].Name + " "
+		if result != expected {
+			t.Errorf("expected %q, got %q", expected, result)
+		}
+	})
+
+	t.Run("complete with navigated selection", func(t *testing.T) {
+		ac := NewAutocomplete(testCommands)
+		ac.Update("/")
+		ac.MoveDown()
+		result := ac.Complete()
+		expected := "/" + ac.Matches()[1].Name + " "
+		if result != expected {
+			t.Errorf("expected %q, got %q", expected, result)
+		}
+	})
+
+	t.Run("complete returns empty when not visible", func(t *testing.T) {
+		ac := NewAutocomplete(testCommands)
+		ac.Update("hello")
+		if result := ac.Complete(); result != "" {
+			t.Errorf("expected empty completion, got %q", result)
+		}
+	})
+}

--- a/pkg/chat/tui/messages.go
+++ b/pkg/chat/tui/messages.go
@@ -1,5 +1,7 @@
 package tui
 
+import "wildgecu/pkg/daemon"
+
 // streamChunkMsg carries a partial text chunk from the streaming response.
 type streamChunkMsg struct {
 	content string
@@ -35,4 +37,9 @@ type sessionErrorMsg struct {
 // informMsg carries a fire-and-forget status message from the agent.
 type informMsg struct {
 	message string
+}
+
+// commandsLoadedMsg carries the command list fetched from the daemon.
+type commandsLoadedMsg struct {
+	commands []daemon.CommandInfo
 }

--- a/pkg/chat/tui/styles.go
+++ b/pkg/chat/tui/styles.go
@@ -10,4 +10,7 @@ var (
 	spinnerStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("205"))
 	toolStyle      = lipgloss.NewStyle().Foreground(lipgloss.Color("214"))
 	informStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("45"))
+
+	acNormalStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
+	acSelectedStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("15")).Background(lipgloss.Color("62"))
 )

--- a/pkg/chat/tui/tui.go
+++ b/pkg/chat/tui/tui.go
@@ -95,7 +95,7 @@ func New(ctx context.Context, client *daemon.Client) Model {
 }
 
 func (m Model) Init() tea.Cmd {
-	return tea.Batch(textinput.Blink, m.createSession, m.fetchCommands)
+	return tea.Batch(textinput.Blink, m.createSession)
 }
 
 // fetchCommands loads the available slash commands from the daemon.
@@ -147,7 +147,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case sessionCreatedMsg:
 		m.sessionID = msg.sessionID
 		m.welcomeText = msg.welcome
-		return m, nil
+		return m, m.fetchCommands
 
 	case commandsLoadedMsg:
 		m.autocomplete = NewAutocomplete(msg.commands)

--- a/pkg/chat/tui/tui.go
+++ b/pkg/chat/tui/tui.go
@@ -60,6 +60,7 @@ type Model struct {
 	textinput      textinput.Model
 	viewport       viewport.Model
 	spinner        spinner.Model
+	autocomplete   *Autocomplete
 	streamIdx      int
 	width          int
 	height         int
@@ -84,16 +85,26 @@ func New(ctx context.Context, client *daemon.Client) Model {
 	sp.Style = spinnerStyle
 
 	return Model{
-		ctx:       ctx,
-		client:    client,
-		textinput: ti,
-		spinner:   sp,
-		program:   &programRef{},
+		ctx:          ctx,
+		client:       client,
+		textinput:    ti,
+		spinner:      sp,
+		program:      &programRef{},
+		autocomplete: NewAutocomplete(nil),
 	}
 }
 
 func (m Model) Init() tea.Cmd {
-	return tea.Batch(textinput.Blink, m.createSession)
+	return tea.Batch(textinput.Blink, m.createSession, m.fetchCommands)
+}
+
+// fetchCommands loads the available slash commands from the daemon.
+func (m Model) fetchCommands() tea.Msg {
+	cmds, err := m.client.ListCommands()
+	if err != nil {
+		return commandsLoadedMsg{} // silently ignore; autocomplete just won't work
+	}
+	return commandsLoadedMsg{commands: cmds}
 }
 
 // createSession sends session.create to the daemon.
@@ -118,7 +129,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
 		m.height = msg.Height
-		vpHeight := m.height - headerHeight - inputHeight - statusHeight - gapLines
+		vpHeight := m.height - headerHeight - inputHeight - statusHeight - gapLines - m.acRows()
 		if vpHeight < 1 {
 			vpHeight = 1
 		}
@@ -138,6 +149,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.welcomeText = msg.welcome
 		return m, nil
 
+	case commandsLoadedMsg:
+		m.autocomplete = NewAutocomplete(msg.commands)
+		return m, nil
+
 	case sessionErrorMsg:
 		m.appendDisplay(errorStyle.Render("Error: " + msg.err.Error()))
 		return m, nil
@@ -155,6 +170,25 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				_ = m.client.InterruptSession(m.sessionID)
 			}
 			return m, nil
+		case tea.KeyUp:
+			if !m.loading && m.autocomplete.Visible() {
+				m.autocomplete.MoveUp()
+				return m, nil
+			}
+		case tea.KeyDown:
+			if !m.loading && m.autocomplete.Visible() {
+				m.autocomplete.MoveDown()
+				return m, nil
+			}
+		case tea.KeyTab:
+			if !m.loading && m.autocomplete.Visible() {
+				if result := m.autocomplete.Complete(); result != "" {
+					m.textinput.SetValue(result)
+					m.textinput.CursorEnd()
+					m.autocomplete.Update(result)
+				}
+				return m, nil
+			}
 		case tea.KeyEnter:
 			if m.loading || m.sessionID == "" {
 				return m, nil
@@ -286,9 +320,35 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		var cmd tea.Cmd
 		m.textinput, cmd = m.textinput.Update(msg)
 		cmds = append(cmds, cmd)
+		m.autocomplete.Update(m.textinput.Value())
+		m.resizeViewport()
 	}
 
 	return m, tea.Batch(cmds...)
+}
+
+const maxAutocompleteRows = 8
+
+func (m *Model) acRows() int {
+	if !m.autocomplete.Visible() {
+		return 0
+	}
+	n := len(m.autocomplete.Matches())
+	if n > maxAutocompleteRows {
+		n = maxAutocompleteRows
+	}
+	return n
+}
+
+func (m *Model) resizeViewport() {
+	if !m.ready {
+		return
+	}
+	vpHeight := m.height - headerHeight - inputHeight - statusHeight - gapLines - m.acRows()
+	if vpHeight < 1 {
+		vpHeight = 1
+	}
+	m.viewport.Height = vpHeight
 }
 
 func (m *Model) renderMarkdown(content string) string {
@@ -350,6 +410,22 @@ func (m Model) View() string {
 		}
 	default:
 		b.WriteString(m.textinput.View())
+	}
+
+	// Autocomplete dropdown.
+	if !m.loading && m.autocomplete.Visible() {
+		b.WriteString("\n")
+		for i, cmd := range m.autocomplete.Matches() {
+			if i >= maxAutocompleteRows {
+				break
+			}
+			if i == m.autocomplete.Selected() {
+				b.WriteString(acSelectedStyle.Render("  /" + cmd.Name + " — " + cmd.Description))
+			} else {
+				b.WriteString(acNormalStyle.Render("  /" + cmd.Name + " — " + cmd.Description))
+			}
+			b.WriteString("\n")
+		}
 	}
 
 	b.WriteString("\n")

--- a/pkg/command/clean.go
+++ b/pkg/command/clean.go
@@ -1,0 +1,47 @@
+package command
+
+import (
+	"context"
+	"fmt"
+)
+
+type sessionIDKey struct{}
+
+// WithSessionID returns a context carrying the given session ID.
+func WithSessionID(ctx context.Context, id string) context.Context {
+	return context.WithValue(ctx, sessionIDKey{}, id)
+}
+
+// SessionIDFromContext extracts the session ID from ctx, or returns "".
+func SessionIDFromContext(ctx context.Context) string {
+	id, _ := ctx.Value(sessionIDKey{}).(string)
+	return id
+}
+
+// ResetFunc resets the session identified by id and returns the new session ID.
+type ResetFunc func(ctx context.Context, id string) (string, error)
+
+// CleanCommand resets the current session.
+type CleanCommand struct {
+	resetFn ResetFunc
+}
+
+// NewCleanCommand creates a /clean command that delegates to resetFn.
+func NewCleanCommand(resetFn ResetFunc) *CleanCommand {
+	return &CleanCommand{resetFn: resetFn}
+}
+
+func (c *CleanCommand) Name() string        { return "clean" }
+func (c *CleanCommand) Description() string { return "Reset the current session" }
+
+func (c *CleanCommand) Execute(ctx context.Context, _ string) (string, error) {
+	sessionID := SessionIDFromContext(ctx)
+	if sessionID == "" {
+		return "", fmt.Errorf("no active session")
+	}
+	newID, err := c.resetFn(ctx, sessionID)
+	if err != nil {
+		return "", fmt.Errorf("reset session: %w", err)
+	}
+	return fmt.Sprintf("Session reset. New session: %s", newID), nil
+}

--- a/pkg/command/clean_test.go
+++ b/pkg/command/clean_test.go
@@ -1,0 +1,80 @@
+package command
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestCleanCommand(t *testing.T) {
+	t.Run("resets session and returns confirmation", func(t *testing.T) {
+		resetCalled := false
+		cmd := NewCleanCommand(func(ctx context.Context, id string) (string, error) {
+			resetCalled = true
+			return "new-session-456", nil
+		})
+
+		ctx := WithSessionID(context.Background(), "old-session-123")
+		result, err := cmd.Execute(ctx, "")
+		if err != nil {
+			t.Fatalf("Execute() error: %v", err)
+		}
+		if !resetCalled {
+			t.Error("expected reset function to be called")
+		}
+		if !strings.Contains(result, "new-session-456") {
+			t.Errorf("expected result to contain new session ID, got %q", result)
+		}
+	})
+
+	t.Run("returns error when no session ID in context", func(t *testing.T) {
+		cmd := NewCleanCommand(func(ctx context.Context, id string) (string, error) {
+			return "", nil
+		})
+
+		_, err := cmd.Execute(context.Background(), "")
+		if err == nil {
+			t.Fatal("expected error when session ID is missing from context")
+		}
+	})
+
+	t.Run("propagates reset error", func(t *testing.T) {
+		cmd := NewCleanCommand(func(ctx context.Context, id string) (string, error) {
+			return "", fmt.Errorf("finalize failed")
+		})
+
+		ctx := WithSessionID(context.Background(), "session-123")
+		_, err := cmd.Execute(ctx, "")
+		if err == nil {
+			t.Fatal("expected error from reset function")
+		}
+	})
+
+	t.Run("name and description", func(t *testing.T) {
+		cmd := NewCleanCommand(nil)
+		if cmd.Name() != "clean" {
+			t.Errorf("expected name %q, got %q", "clean", cmd.Name())
+		}
+		if cmd.Description() == "" {
+			t.Error("expected non-empty description")
+		}
+	})
+}
+
+func TestSessionIDContext(t *testing.T) {
+	t.Run("round trip", func(t *testing.T) {
+		ctx := WithSessionID(context.Background(), "abc-123")
+		got := SessionIDFromContext(ctx)
+		if got != "abc-123" {
+			t.Errorf("expected %q, got %q", "abc-123", got)
+		}
+	})
+
+	t.Run("empty when not set", func(t *testing.T) {
+		got := SessionIDFromContext(context.Background())
+		if got != "" {
+			t.Errorf("expected empty, got %q", got)
+		}
+	})
+}

--- a/pkg/command/help.go
+++ b/pkg/command/help.go
@@ -1,0 +1,39 @@
+package command
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// HelpCommand is a built-in command that lists all available commands.
+type HelpCommand struct {
+	registry *Registry
+}
+
+// NewHelpCommand creates a /help command bound to the given registry.
+func NewHelpCommand(r *Registry) *HelpCommand {
+	return &HelpCommand{registry: r}
+}
+
+func (c *HelpCommand) Name() string        { return "help" }
+func (c *HelpCommand) Description() string { return "Show all available commands" }
+
+func (c *HelpCommand) Execute(_ context.Context, _ string) (string, error) {
+	entries := c.registry.List()
+	if len(entries) == 0 {
+		return "No commands available.", nil
+	}
+
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Name < entries[j].Name
+	})
+
+	var b strings.Builder
+	b.WriteString("Available commands:\n")
+	for _, e := range entries {
+		fmt.Fprintf(&b, "  /%s — %s\n", e.Name, e.Description)
+	}
+	return b.String(), nil
+}

--- a/pkg/command/help_test.go
+++ b/pkg/command/help_test.go
@@ -1,0 +1,74 @@
+package command
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestHelpCommand(t *testing.T) {
+	t.Run("lists commands sorted", func(t *testing.T) {
+		r := NewRegistry("")
+		r.Register(&stubCommand{name: "zoo", desc: "Last alphabetically"})
+		r.Register(&stubCommand{name: "alpha", desc: "First alphabetically"})
+
+		help := NewHelpCommand(r)
+		r.Register(help)
+
+		out, err := help.Execute(context.Background(), "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if !strings.Contains(out, "/alpha") {
+			t.Error("expected output to contain /alpha")
+		}
+		if !strings.Contains(out, "/help") {
+			t.Error("expected output to contain /help")
+		}
+		if !strings.Contains(out, "/zoo") {
+			t.Error("expected output to contain /zoo")
+		}
+
+		// Verify sorted order: alpha before help before zoo
+		alphaIdx := strings.Index(out, "/alpha")
+		helpIdx := strings.Index(out, "/help")
+		zooIdx := strings.Index(out, "/zoo")
+		if alphaIdx >= helpIdx || helpIdx >= zooIdx {
+			t.Errorf("expected sorted order, got alpha=%d help=%d zoo=%d", alphaIdx, helpIdx, zooIdx)
+		}
+	})
+
+	t.Run("empty registry", func(t *testing.T) {
+		r := NewRegistry("")
+		help := NewHelpCommand(r)
+
+		out, err := help.Execute(context.Background(), "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if out != "No commands available." {
+			t.Errorf("expected empty message, got %q", out)
+		}
+	})
+
+	t.Run("includes skills", func(t *testing.T) {
+		dir := t.TempDir()
+		writeTestSkill(t, dir, "---\nname: deploy\ndescription: Deploy the app\n---\ncontent")
+
+		r := NewRegistry(dir)
+		help := NewHelpCommand(r)
+		r.Register(help)
+
+		out, err := help.Execute(context.Background(), "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !strings.Contains(out, "/deploy") {
+			t.Error("expected output to contain /deploy")
+		}
+		if !strings.Contains(out, "/help") {
+			t.Error("expected output to contain /help")
+		}
+	})
+}

--- a/pkg/command/parser.go
+++ b/pkg/command/parser.go
@@ -1,0 +1,23 @@
+package command
+
+import "strings"
+
+// Parse splits a slash command input into the command name and the raw
+// argument string. It returns ("", "") if the input is not a valid slash
+// command (i.e. does not start with "/").
+//
+// Examples:
+//
+//	Parse("/help")              → ("help", "")
+//	Parse("/skill install foo") → ("skill", "install foo")
+func Parse(input string) (name, args string) {
+	if !strings.HasPrefix(input, "/") {
+		return "", ""
+	}
+	input = input[1:] // strip leading "/"
+	idx := strings.IndexByte(input, ' ')
+	if idx < 0 {
+		return input, ""
+	}
+	return input[:idx], input[idx+1:]
+}

--- a/pkg/command/parser_test.go
+++ b/pkg/command/parser_test.go
@@ -1,0 +1,65 @@
+package command
+
+import "testing"
+
+func TestParse(t *testing.T) {
+	t.Run("command without args", func(t *testing.T) {
+		name, args := Parse("/help")
+		if name != "help" {
+			t.Errorf("expected name %q, got %q", "help", name)
+		}
+		if args != "" {
+			t.Errorf("expected empty args, got %q", args)
+		}
+	})
+
+	t.Run("command with args", func(t *testing.T) {
+		name, args := Parse("/skill install my-skill")
+		if name != "skill" {
+			t.Errorf("expected name %q, got %q", "skill", name)
+		}
+		if args != "install my-skill" {
+			t.Errorf("expected args %q, got %q", "install my-skill", args)
+		}
+	})
+
+	t.Run("command with leading spaces in args", func(t *testing.T) {
+		name, args := Parse("/echo   hello")
+		if name != "echo" {
+			t.Errorf("expected name %q, got %q", "echo", name)
+		}
+		if args != "  hello" {
+			t.Errorf("expected args %q, got %q", "  hello", args)
+		}
+	})
+
+	t.Run("slash only", func(t *testing.T) {
+		name, args := Parse("/")
+		if name != "" {
+			t.Errorf("expected empty name, got %q", name)
+		}
+		if args != "" {
+			t.Errorf("expected empty args, got %q", args)
+		}
+	})
+
+	t.Run("empty string", func(t *testing.T) {
+		name, args := Parse("")
+		if name != "" {
+			t.Errorf("expected empty name, got %q", name)
+		}
+		if args != "" {
+			t.Errorf("expected empty args, got %q", args)
+		}
+	})
+
+	t.Run("no slash prefix", func(t *testing.T) {
+		name, args := Parse("hello world")
+		if name != "" {
+			t.Errorf("expected empty name, got %q", name)
+		}
+		if args != "" {
+			t.Errorf("expected empty args, got %q", args)
+		}
+	})
+}

--- a/pkg/command/registry.go
+++ b/pkg/command/registry.go
@@ -1,0 +1,92 @@
+package command
+
+import (
+	"context"
+
+	"wildgecu/pkg/skill"
+)
+
+// Command is the interface for a slash command.
+type Command interface {
+	Name() string
+	Description() string
+	Execute(ctx context.Context, args string) (string, error)
+}
+
+// Entry is a name+description pair returned by Registry.List.
+type Entry struct {
+	Name        string
+	Description string
+}
+
+// Registry holds built-in commands and falls back to skills for resolution.
+type Registry struct {
+	builtins  map[string]Command
+	skillsDir string
+}
+
+// NewRegistry creates a new command registry. skillsDir is the path to the
+// skills directory used for fallback resolution; it may be empty to disable
+// skill fallback.
+func NewRegistry(skillsDir string) *Registry {
+	return &Registry{
+		builtins:  make(map[string]Command),
+		skillsDir: skillsDir,
+	}
+}
+
+// Register adds a built-in command to the registry.
+func (r *Registry) Register(cmd Command) {
+	r.builtins[cmd.Name()] = cmd
+}
+
+// Resolve looks up a command by name. Built-in commands take priority; if not
+// found, it falls back to loading a skill with the same name.
+func (r *Registry) Resolve(name string) Command {
+	if cmd, ok := r.builtins[name]; ok {
+		return cmd
+	}
+	if r.skillsDir == "" {
+		return nil
+	}
+	s, err := skill.Load(r.skillsDir, name)
+	if err != nil {
+		return nil
+	}
+	return &skillCommand{skill: s}
+}
+
+// List returns all available commands (built-in + skills), with built-in
+// descriptions taking priority over skills with the same name.
+func (r *Registry) List() []Entry {
+	seen := make(map[string]bool)
+	var entries []Entry
+
+	for _, cmd := range r.builtins {
+		entries = append(entries, Entry{Name: cmd.Name(), Description: cmd.Description()})
+		seen[cmd.Name()] = true
+	}
+
+	if r.skillsDir != "" {
+		skills, _ := skill.LoadAll(r.skillsDir)
+		for _, s := range skills {
+			if seen[s.Name] {
+				continue
+			}
+			entries = append(entries, Entry{Name: s.Name, Description: s.Description})
+		}
+	}
+
+	return entries
+}
+
+// skillCommand adapts a skill.Skill to the Command interface.
+type skillCommand struct {
+	skill *skill.Skill
+}
+
+func (c *skillCommand) Name() string        { return c.skill.Name }
+func (c *skillCommand) Description() string { return c.skill.Description }
+func (c *skillCommand) Execute(_ context.Context, _ string) (string, error) {
+	return c.skill.Content, nil
+}

--- a/pkg/command/registry.go
+++ b/pkg/command/registry.go
@@ -80,13 +80,20 @@ func (r *Registry) List() []Entry {
 	return entries
 }
 
+// SkillRunner is implemented by commands backed by a skill that require
+// an LLM turn with the skill content as system context.
+type SkillRunner interface {
+	SkillContent() string
+}
+
 // skillCommand adapts a skill.Skill to the Command interface.
 type skillCommand struct {
 	skill *skill.Skill
 }
 
-func (c *skillCommand) Name() string        { return c.skill.Name }
-func (c *skillCommand) Description() string { return c.skill.Description }
+func (c *skillCommand) Name() string           { return c.skill.Name }
+func (c *skillCommand) Description() string    { return c.skill.Description }
+func (c *skillCommand) SkillContent() string   { return c.skill.Content }
 func (c *skillCommand) Execute(_ context.Context, _ string) (string, error) {
 	return c.skill.Content, nil
 }

--- a/pkg/command/registry_test.go
+++ b/pkg/command/registry_test.go
@@ -1,0 +1,122 @@
+package command
+
+import (
+	"context"
+	"testing"
+
+	"wildgecu/pkg/skill"
+)
+
+// stubCommand is a simple Command implementation for testing.
+type stubCommand struct {
+	name string
+	desc string
+}
+
+func (c *stubCommand) Name() string        { return c.name }
+func (c *stubCommand) Description() string { return c.desc }
+func (c *stubCommand) Execute(_ context.Context, _ string) (string, error) {
+	return "executed " + c.name, nil
+}
+
+func TestRegistryResolveBuiltin(t *testing.T) {
+	r := NewRegistry("")
+	r.Register(&stubCommand{name: "help", desc: "Show help"})
+
+	cmd := r.Resolve("help")
+	if cmd == nil {
+		t.Fatal("expected to resolve built-in command 'help'")
+	}
+	if cmd.Name() != "help" {
+		t.Errorf("expected name %q, got %q", "help", cmd.Name())
+	}
+}
+
+func TestRegistryResolveUnknown(t *testing.T) {
+	r := NewRegistry("")
+	cmd := r.Resolve("nonexistent")
+	if cmd != nil {
+		t.Errorf("expected nil for unknown command, got %v", cmd)
+	}
+}
+
+func TestRegistryResolveSkillFallback(t *testing.T) {
+	dir := t.TempDir()
+	writeTestSkill(t, dir, "---\nname: deploy\ndescription: Deploy the app\n---\nDeploy instructions")
+
+	r := NewRegistry(dir)
+	cmd := r.Resolve("deploy")
+	if cmd == nil {
+		t.Fatal("expected to resolve skill command 'deploy'")
+	}
+	if cmd.Name() != "deploy" {
+		t.Errorf("expected name %q, got %q", "deploy", cmd.Name())
+	}
+	if cmd.Description() != "Deploy the app" {
+		t.Errorf("expected description %q, got %q", "Deploy the app", cmd.Description())
+	}
+}
+
+func TestRegistryBuiltinPriorityOverSkill(t *testing.T) {
+	dir := t.TempDir()
+	writeTestSkill(t, dir, "---\nname: help\ndescription: Skill help\n---\nSkill help content")
+
+	r := NewRegistry(dir)
+	r.Register(&stubCommand{name: "help", desc: "Built-in help"})
+
+	cmd := r.Resolve("help")
+	if cmd == nil {
+		t.Fatal("expected to resolve command 'help'")
+	}
+	if cmd.Description() != "Built-in help" {
+		t.Errorf("expected built-in to win, got description %q", cmd.Description())
+	}
+}
+
+func TestRegistryListMerging(t *testing.T) {
+	dir := t.TempDir()
+	writeTestSkill(t, dir, "---\nname: deploy\ndescription: Deploy the app\n---\nDeploy instructions")
+	writeTestSkill(t, dir, "---\nname: help\ndescription: Skill help\n---\nOverridden by built-in")
+
+	r := NewRegistry(dir)
+	r.Register(&stubCommand{name: "help", desc: "Built-in help"})
+
+	entries := r.List()
+
+	// Should have 2 entries: help (built-in) and deploy (skill).
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d: %v", len(entries), entries)
+	}
+
+	found := map[string]string{}
+	for _, e := range entries {
+		found[e.Name] = e.Description
+	}
+
+	if found["help"] != "Built-in help" {
+		t.Errorf("expected 'help' from built-in, got %q", found["help"])
+	}
+	if found["deploy"] != "Deploy the app" {
+		t.Errorf("expected 'deploy' from skill, got %q", found["deploy"])
+	}
+}
+
+func TestRegistryListEmpty(t *testing.T) {
+	r := NewRegistry("")
+	entries := r.List()
+	if len(entries) != 0 {
+		t.Errorf("expected 0 entries, got %d", len(entries))
+	}
+}
+
+// writeTestSkill creates a skill directory with a SKILL.md file for testing.
+func writeTestSkill(t *testing.T, dir, data string) {
+	t.Helper()
+	s, err := skill.Parse([]byte(data))
+	if err != nil {
+		t.Fatalf("parse test skill: %v", err)
+	}
+	if err := skill.Save(dir, s); err != nil {
+		t.Fatalf("save test skill: %v", err)
+	}
+}

--- a/pkg/command/registry_test.go
+++ b/pkg/command/registry_test.go
@@ -109,6 +109,36 @@ func TestRegistryListEmpty(t *testing.T) {
 	}
 }
 
+func TestSkillCommandImplementsSkillRunner(t *testing.T) {
+	dir := t.TempDir()
+	writeTestSkill(t, dir, "---\nname: review\ndescription: Code review\n---\nReview the code carefully")
+
+	r := NewRegistry(dir)
+	cmd := r.Resolve("review")
+	if cmd == nil {
+		t.Fatal("expected to resolve skill command")
+	}
+
+	runner, ok := cmd.(SkillRunner)
+	if !ok {
+		t.Fatal("expected skill command to implement SkillRunner")
+	}
+
+	if got := runner.SkillContent(); got != "Review the code carefully" {
+		t.Errorf("SkillContent() = %q, want %q", got, "Review the code carefully")
+	}
+}
+
+func TestBuiltinCommandNotSkillRunner(t *testing.T) {
+	r := NewRegistry("")
+	r.Register(&stubCommand{name: "help", desc: "Show help"})
+
+	cmd := r.Resolve("help")
+	if _, ok := cmd.(SkillRunner); ok {
+		t.Error("expected built-in command NOT to implement SkillRunner")
+	}
+}
+
 // writeTestSkill creates a skill directory with a SKILL.md file for testing.
 func writeTestSkill(t *testing.T, dir, data string) {
 	t.Helper()

--- a/pkg/command/status.go
+++ b/pkg/command/status.go
@@ -1,0 +1,47 @@
+package command
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// StatusInfo holds the session information returned by StatusFunc.
+type StatusInfo struct {
+	SessionID    string
+	MessageCount int
+	Provider     string
+	Model        string
+	Uptime       time.Duration
+}
+
+// StatusFunc returns session information for the given session ID.
+type StatusFunc func(ctx context.Context, id string) (StatusInfo, error)
+
+// StatusCommand displays current session information.
+type StatusCommand struct {
+	statusFn StatusFunc
+}
+
+// NewStatusCommand creates a /status command that delegates to statusFn.
+func NewStatusCommand(statusFn StatusFunc) *StatusCommand {
+	return &StatusCommand{statusFn: statusFn}
+}
+
+func (c *StatusCommand) Name() string        { return "status" }
+func (c *StatusCommand) Description() string { return "Show current session info" }
+
+func (c *StatusCommand) Execute(ctx context.Context, _ string) (string, error) {
+	sessionID := SessionIDFromContext(ctx)
+	if sessionID == "" {
+		return "", fmt.Errorf("no active session")
+	}
+	info, err := c.statusFn(ctx, sessionID)
+	if err != nil {
+		return "", fmt.Errorf("get session status: %w", err)
+	}
+	return fmt.Sprintf(
+		"Session:  %s\nMessages: %d\nProvider: %s\nModel:    %s\nUptime:   %s",
+		info.SessionID, info.MessageCount, info.Provider, info.Model, info.Uptime,
+	), nil
+}

--- a/pkg/command/status_test.go
+++ b/pkg/command/status_test.go
@@ -1,0 +1,68 @@
+package command
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestStatusCommand(t *testing.T) {
+	t.Run("returns formatted session info", func(t *testing.T) {
+		cmd := NewStatusCommand(func(_ context.Context, id string) (StatusInfo, error) {
+			return StatusInfo{
+				SessionID:    "sess-abc-123",
+				MessageCount: 42,
+				Provider:     "openai",
+				Model:        "gpt-4o",
+				Uptime:       3*time.Hour + 15*time.Minute,
+			}, nil
+		})
+
+		ctx := WithSessionID(context.Background(), "sess-abc-123")
+		result, err := cmd.Execute(ctx, "")
+		if err != nil {
+			t.Fatalf("Execute() error: %v", err)
+		}
+
+		for _, want := range []string{"sess-abc-123", "42", "openai", "gpt-4o", "3h15m"} {
+			if !strings.Contains(result, want) {
+				t.Errorf("expected result to contain %q, got:\n%s", want, result)
+			}
+		}
+	})
+
+	t.Run("returns error when no session ID in context", func(t *testing.T) {
+		cmd := NewStatusCommand(func(_ context.Context, id string) (StatusInfo, error) {
+			return StatusInfo{}, nil
+		})
+
+		_, err := cmd.Execute(context.Background(), "")
+		if err == nil {
+			t.Fatal("expected error when session ID is missing from context")
+		}
+	})
+
+	t.Run("propagates status function error", func(t *testing.T) {
+		cmd := NewStatusCommand(func(_ context.Context, id string) (StatusInfo, error) {
+			return StatusInfo{}, fmt.Errorf("session not found")
+		})
+
+		ctx := WithSessionID(context.Background(), "sess-123")
+		_, err := cmd.Execute(ctx, "")
+		if err == nil {
+			t.Fatal("expected error from status function")
+		}
+	})
+
+	t.Run("name and description", func(t *testing.T) {
+		cmd := NewStatusCommand(nil)
+		if cmd.Name() != "status" {
+			t.Errorf("expected name %q, got %q", "status", cmd.Name())
+		}
+		if cmd.Description() == "" {
+			t.Error("expected non-empty description")
+		}
+	})
+}

--- a/pkg/daemon/chat_client.go
+++ b/pkg/daemon/chat_client.go
@@ -8,13 +8,14 @@ import (
 
 // Event is a server→client message over the NDJSON socket.
 type Event struct {
-	Type      string `json:"type"`
-	SessionID string `json:"session_id,omitempty"`
-	Content   string `json:"content,omitempty"`
-	Welcome   string `json:"welcome,omitempty"`
-	Name      string `json:"name,omitempty"`
-	Args      string `json:"args,omitempty"`
-	Message   string `json:"message,omitempty"`
+	Type      string        `json:"type"`
+	SessionID string        `json:"session_id,omitempty"`
+	Content   string        `json:"content,omitempty"`
+	Welcome   string        `json:"welcome,omitempty"`
+	Name      string        `json:"name,omitempty"`
+	Args      string        `json:"args,omitempty"`
+	Message   string        `json:"message,omitempty"`
+	Commands  []CommandInfo `json:"commands,omitempty"`
 }
 
 // request is a client→server message over the NDJSON socket.
@@ -97,6 +98,21 @@ func (c *Client) ReadEvent() (*Event, error) {
 	return &ev, nil
 }
 
+
+// ListCommands asks the daemon for the full list of available slash commands.
+func (c *Client) ListCommands() ([]CommandInfo, error) {
+	if err := c.encoder.Encode(request{Type: "commands.list"}); err != nil {
+		return nil, fmt.Errorf("send commands.list: %w", err)
+	}
+	var ev Event
+	if err := c.decoder.Decode(&ev); err != nil {
+		return nil, fmt.Errorf("read commands.list: %w", err)
+	}
+	if ev.Type == "error" {
+		return nil, fmt.Errorf("commands.list failed: %s", ev.Message)
+	}
+	return ev.Commands, nil
+}
 
 // InterruptSession asks the daemon to interrupt the current turn of the session.
 func (c *Client) InterruptSession(sessionID string) error {

--- a/pkg/daemon/chat_handler.go
+++ b/pkg/daemon/chat_handler.go
@@ -1,7 +1,6 @@
 package daemon
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -97,7 +96,7 @@ func (s *SocketServer) dispatchChatRequest(req *ChatRequest, send func(ChatEvent
 		})
 
 	case "message":
-		if strings.HasPrefix(req.Content, "/") {
+		if s.commands != nil && strings.HasPrefix(req.Content, "/") {
 			go s.handleSlashCommand(req, send, logger)
 			return
 		}
@@ -126,7 +125,7 @@ func (s *SocketServer) handleSlashCommand(req *ChatRequest, send func(ChatEvent)
 		return
 	}
 
-	result, err := cmd.Execute(context.Background(), args)
+	result, err := cmd.Execute(s.ctx, args)
 	if err != nil {
 		logger.Error("slash command error", "command", name, "error", err)
 		send(ChatEvent{Type: "error", Message: err.Error()})

--- a/pkg/daemon/chat_handler.go
+++ b/pkg/daemon/chat_handler.go
@@ -125,7 +125,8 @@ func (s *SocketServer) handleSlashCommand(req *ChatRequest, send func(ChatEvent)
 		return
 	}
 
-	result, err := cmd.Execute(s.ctx, args)
+	ctx := command.WithSessionID(s.ctx, req.SessionID)
+	result, err := cmd.Execute(ctx, args)
 	if err != nil {
 		logger.Error("slash command error", "command", name, "error", err)
 		send(ChatEvent{Type: "error", Message: err.Error()})

--- a/pkg/daemon/chat_handler.go
+++ b/pkg/daemon/chat_handler.go
@@ -20,15 +20,22 @@ type ChatRequest struct {
 	WorkDir   string `json:"work_dir,omitempty"`
 }
 
+// CommandInfo is a name+description pair returned by the commands.list event.
+type CommandInfo struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
 // ChatEvent is a server→client message on a NDJSON chat connection.
 type ChatEvent struct {
-	Type      string `json:"type"`
-	SessionID string `json:"session_id,omitempty"`
-	Content   string `json:"content,omitempty"`
-	Welcome   string `json:"welcome,omitempty"`
-	Name      string `json:"name,omitempty"`
-	Args      string `json:"args,omitempty"`
-	Message   string `json:"message,omitempty"`
+	Type      string        `json:"type"`
+	SessionID string        `json:"session_id,omitempty"`
+	Content   string        `json:"content,omitempty"`
+	Welcome   string        `json:"welcome,omitempty"`
+	Name      string        `json:"name,omitempty"`
+	Args      string        `json:"args,omitempty"`
+	Message   string        `json:"message,omitempty"`
+	Commands  []CommandInfo `json:"commands,omitempty"`
 }
 
 // handleChatConnection processes a long-lived NDJSON chat connection.
@@ -109,6 +116,15 @@ func (s *SocketServer) dispatchChatRequest(req *ChatRequest, send func(ChatEvent
 	case "session.close":
 		logger.Info("session closed", "session_id", req.SessionID)
 		sessions.Close(s.ctx, req.SessionID)
+
+	case "commands.list":
+		var cmds []CommandInfo
+		if s.commands != nil {
+			for _, e := range s.commands.List() {
+				cmds = append(cmds, CommandInfo{Name: e.Name, Description: e.Description})
+			}
+		}
+		send(ChatEvent{Type: "commands.list", Commands: cmds})
 	}
 }
 

--- a/pkg/daemon/chat_handler.go
+++ b/pkg/daemon/chat_handler.go
@@ -1,10 +1,15 @@
 package daemon
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"net"
+	"strings"
 	"sync"
+
+	"wildgecu/pkg/command"
 )
 
 // ChatRequest is a client→server message on a NDJSON chat connection.
@@ -92,6 +97,10 @@ func (s *SocketServer) dispatchChatRequest(req *ChatRequest, send func(ChatEvent
 		})
 
 	case "message":
+		if strings.HasPrefix(req.Content, "/") {
+			go s.handleSlashCommand(req, send, logger)
+			return
+		}
 		go s.handleChatMessage(req, send, sessions, logger)
 
 	case "session.interrupt":
@@ -102,6 +111,28 @@ func (s *SocketServer) dispatchChatRequest(req *ChatRequest, send func(ChatEvent
 		logger.Info("session closed", "session_id", req.SessionID)
 		sessions.Close(s.ctx, req.SessionID)
 	}
+}
+
+func (s *SocketServer) handleSlashCommand(req *ChatRequest, send func(ChatEvent), logger *slog.Logger) {
+	name, args := command.Parse(req.Content)
+	if name == "" {
+		send(ChatEvent{Type: "done", Content: "Usage: /<command> [args]"})
+		return
+	}
+
+	cmd := s.commands.Resolve(name)
+	if cmd == nil {
+		send(ChatEvent{Type: "done", Content: fmt.Sprintf("Unknown command: /%s", name)})
+		return
+	}
+
+	result, err := cmd.Execute(context.Background(), args)
+	if err != nil {
+		logger.Error("slash command error", "command", name, "error", err)
+		send(ChatEvent{Type: "error", Message: err.Error()})
+		return
+	}
+	send(ChatEvent{Type: "done", Content: result})
 }
 
 func (s *SocketServer) handleChatMessage(req *ChatRequest, send func(ChatEvent), sessions *SessionManager, logger *slog.Logger) {

--- a/pkg/daemon/chat_handler.go
+++ b/pkg/daemon/chat_handler.go
@@ -97,7 +97,7 @@ func (s *SocketServer) dispatchChatRequest(req *ChatRequest, send func(ChatEvent
 
 	case "message":
 		if s.commands != nil && strings.HasPrefix(req.Content, "/") {
-			go s.handleSlashCommand(req, send, logger)
+			go s.handleSlashCommand(req, send, sessions, logger)
 			return
 		}
 		go s.handleChatMessage(req, send, sessions, logger)
@@ -112,7 +112,7 @@ func (s *SocketServer) dispatchChatRequest(req *ChatRequest, send func(ChatEvent
 	}
 }
 
-func (s *SocketServer) handleSlashCommand(req *ChatRequest, send func(ChatEvent), logger *slog.Logger) {
+func (s *SocketServer) handleSlashCommand(req *ChatRequest, send func(ChatEvent), sessions *SessionManager, logger *slog.Logger) {
 	name, args := command.Parse(req.Content)
 	if name == "" {
 		send(ChatEvent{Type: "done", Content: "Usage: /<command> [args]"})
@@ -125,6 +125,12 @@ func (s *SocketServer) handleSlashCommand(req *ChatRequest, send func(ChatEvent)
 		return
 	}
 
+	// Skill commands run a streaming LLM turn with skill content as system context.
+	if runner, ok := cmd.(command.SkillRunner); ok {
+		s.handleSkillCommand(req, runner, args, send, sessions, logger)
+		return
+	}
+
 	ctx := command.WithSessionID(s.ctx, req.SessionID)
 	result, err := cmd.Execute(ctx, args)
 	if err != nil {
@@ -133,6 +139,26 @@ func (s *SocketServer) handleSlashCommand(req *ChatRequest, send func(ChatEvent)
 		return
 	}
 	send(ChatEvent{Type: "done", Content: result})
+}
+
+func (s *SocketServer) handleSkillCommand(req *ChatRequest, runner command.SkillRunner, userInput string, send func(ChatEvent), sessions *SessionManager, logger *slog.Logger) {
+	onChunk := func(chunk string) {
+		send(ChatEvent{Type: "chunk", Content: chunk})
+	}
+	onToolCall := func(name string, args string) {
+		send(ChatEvent{Type: "tool_call", Name: name, Args: args})
+	}
+	onInform := func(message string) {
+		send(ChatEvent{Type: "inform", Content: message})
+	}
+
+	content, err := sessions.RunSkillTurnStream(s.ctx, req.SessionID, runner.SkillContent(), userInput, onChunk, onToolCall, onInform)
+	if err != nil {
+		logger.Error("skill command error", "error", err)
+		send(ChatEvent{Type: "error", Message: err.Error()})
+		return
+	}
+	send(ChatEvent{Type: "done", Content: content})
 }
 
 func (s *SocketServer) handleChatMessage(req *ChatRequest, send func(ChatEvent), sessions *SessionManager, logger *slog.Logger) {

--- a/pkg/daemon/chat_handler_test.go
+++ b/pkg/daemon/chat_handler_test.go
@@ -5,9 +5,11 @@ import (
 	"encoding/json"
 	"log/slog"
 	"net"
+	"strings"
 	"testing"
 	"time"
 
+	"wildgecu/pkg/command"
 	"wildgecu/pkg/provider"
 	"wildgecu/pkg/session"
 )
@@ -79,5 +81,117 @@ func TestInterruptDuringMessage(t *testing.T) {
 	}
 	if ev.Type != "error" {
 		t.Fatalf("expected error event after interrupt, got %s: %+v", ev.Type, ev)
+	}
+}
+
+// newTestServer creates a SocketServer with a command registry containing /help.
+func newTestServer(ctx context.Context) *SocketServer {
+	reg := command.NewRegistry("")
+	help := command.NewHelpCommand(reg)
+	reg.Register(help)
+	return &SocketServer{ctx: ctx, commands: reg}
+}
+
+func TestSlashCommandHelp(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	srv := newTestServer(ctx)
+
+	sm := &SessionManager{
+		chatCfg: &session.Config{
+			Provider:    blockingProvider{},
+			WelcomeText: "hello",
+		},
+		sessions: make(map[string]*ManagedSession),
+	}
+
+	clientConn, serverConn := net.Pipe()
+	defer clientConn.Close()
+	defer serverConn.Close()
+
+	logger := slog.Default()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		firstReq := &ChatRequest{Type: "session.create"}
+		srv.handleChatConnection(serverConn, firstReq, sm, logger)
+	}()
+
+	enc := json.NewEncoder(clientConn)
+	dec := json.NewDecoder(clientConn)
+
+	// Read session.created
+	var created ChatEvent
+	if err := dec.Decode(&created); err != nil {
+		t.Fatalf("decode session.created: %v", err)
+	}
+
+	// Send /help command
+	enc.Encode(ChatRequest{Type: "message", SessionID: created.SessionID, Content: "/help"})
+
+	var ev ChatEvent
+	if err := dec.Decode(&ev); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if ev.Type != "done" {
+		t.Fatalf("expected done event, got %s: %+v", ev.Type, ev)
+	}
+	if ev.Content == "" {
+		t.Fatal("expected non-empty help output")
+	}
+	if !strings.Contains(ev.Content, "/help") {
+		t.Errorf("expected help output to contain '/help', got %q", ev.Content)
+	}
+}
+
+func TestSlashCommandUnknown(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	srv := newTestServer(ctx)
+
+	sm := &SessionManager{
+		chatCfg: &session.Config{
+			Provider:    blockingProvider{},
+			WelcomeText: "hello",
+		},
+		sessions: make(map[string]*ManagedSession),
+	}
+
+	clientConn, serverConn := net.Pipe()
+	defer clientConn.Close()
+	defer serverConn.Close()
+
+	logger := slog.Default()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		firstReq := &ChatRequest{Type: "session.create"}
+		srv.handleChatConnection(serverConn, firstReq, sm, logger)
+	}()
+
+	enc := json.NewEncoder(clientConn)
+	dec := json.NewDecoder(clientConn)
+
+	var created ChatEvent
+	if err := dec.Decode(&created); err != nil {
+		t.Fatalf("decode session.created: %v", err)
+	}
+
+	// Send unknown slash command
+	enc.Encode(ChatRequest{Type: "message", SessionID: created.SessionID, Content: "/typo"})
+
+	var ev ChatEvent
+	if err := dec.Decode(&ev); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if ev.Type != "done" {
+		t.Fatalf("expected done event, got %s: %+v", ev.Type, ev)
+	}
+	if !strings.Contains(ev.Content, "Unknown command: /typo") {
+		t.Errorf("expected unknown command error, got %q", ev.Content)
 	}
 }

--- a/pkg/daemon/chat_handler_test.go
+++ b/pkg/daemon/chat_handler_test.go
@@ -92,6 +92,19 @@ func newTestServer(ctx context.Context) *SocketServer {
 	return &SocketServer{ctx: ctx, commands: reg}
 }
 
+// newTestServerWithClean creates a SocketServer with /help and /clean commands
+// backed by the given SessionManager.
+func newTestServerWithClean(ctx context.Context, sm *SessionManager) *SocketServer {
+	reg := command.NewRegistry("")
+	help := command.NewHelpCommand(reg)
+	reg.Register(help)
+	clean := command.NewCleanCommand(func(cmdCtx context.Context, id string) (string, error) {
+		return sm.ResetSession(cmdCtx, id)
+	})
+	reg.Register(clean)
+	return &SocketServer{ctx: ctx, commands: reg}
+}
+
 func TestSlashCommandHelp(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -193,5 +206,77 @@ func TestSlashCommandUnknown(t *testing.T) {
 	}
 	if !strings.Contains(ev.Content, "Unknown command: /typo") {
 		t.Errorf("expected unknown command error, got %q", ev.Content)
+	}
+}
+
+func TestSlashCommandCleanResetsSession(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sm := newTestSessionManager(t)
+	srv := newTestServerWithClean(ctx, sm)
+
+	clientConn, serverConn := net.Pipe()
+	defer clientConn.Close()
+	defer serverConn.Close()
+
+	logger := slog.Default()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		firstReq := &ChatRequest{Type: "session.create"}
+		srv.handleChatConnection(serverConn, firstReq, sm, logger)
+	}()
+
+	enc := json.NewEncoder(clientConn)
+	dec := json.NewDecoder(clientConn)
+
+	// Read session.created
+	var created ChatEvent
+	if err := dec.Decode(&created); err != nil {
+		t.Fatalf("decode session.created: %v", err)
+	}
+	oldSessionID := created.SessionID
+
+	// Verify old session exists.
+	if sm.Get(oldSessionID) == nil {
+		t.Fatal("expected old session to exist before /clean")
+	}
+
+	// Send /clean command
+	if err := enc.Encode(ChatRequest{Type: "message", SessionID: oldSessionID, Content: "/clean"}); err != nil {
+		t.Fatalf("encode /clean: %v", err)
+	}
+
+	var ev ChatEvent
+	if err := dec.Decode(&ev); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	if ev.Type != "done" {
+		t.Fatalf("expected done event, got %s: %+v", ev.Type, ev)
+	}
+	if !strings.Contains(ev.Content, "Session reset") {
+		t.Errorf("expected reset confirmation, got %q", ev.Content)
+	}
+	if !strings.Contains(ev.Content, "New session:") {
+		t.Errorf("expected new session info, got %q", ev.Content)
+	}
+
+	// Old session should be removed.
+	if sm.Get(oldSessionID) != nil {
+		t.Error("expected old session to be removed after /clean")
+	}
+
+	// Extract new session ID from response and verify it exists.
+	const prefix = "New session: "
+	idx := strings.Index(ev.Content, prefix)
+	if idx < 0 {
+		t.Fatalf("could not find new session ID in response: %q", ev.Content)
+	}
+	newSessionID := ev.Content[idx+len(prefix):]
+	if sm.Get(newSessionID) == nil {
+		t.Error("expected new session to exist after /clean")
 	}
 }

--- a/pkg/daemon/chat_handler_test.go
+++ b/pkg/daemon/chat_handler_test.go
@@ -14,6 +14,19 @@ import (
 	"wildgecu/pkg/session"
 )
 
+// fakeSkillCommand implements command.Command and command.SkillRunner for testing.
+type fakeSkillCommand struct {
+	name    string
+	content string
+}
+
+func (c *fakeSkillCommand) Name() string                              { return c.name }
+func (c *fakeSkillCommand) Description() string                       { return "fake skill" }
+func (c *fakeSkillCommand) Execute(_ context.Context, _ string) (string, error) {
+	return c.content, nil
+}
+func (c *fakeSkillCommand) SkillContent() string { return c.content }
+
 // blockingProvider blocks on Generate until the context is cancelled.
 type blockingProvider struct{}
 
@@ -278,5 +291,52 @@ func TestSlashCommandCleanResetsSession(t *testing.T) {
 	newSessionID := ev.Content[idx+len(prefix):]
 	if sm.Get(newSessionID) == nil {
 		t.Error("expected new session to exist after /clean")
+	}
+}
+
+func TestSlashSkillCommandDispatch(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sm := newTestSessionManager(t)
+
+	reg := command.NewRegistry("")
+	reg.Register(&fakeSkillCommand{name: "review", content: "Review the code carefully."})
+	srv := &SocketServer{ctx: ctx, commands: reg}
+
+	clientConn, serverConn := net.Pipe()
+	defer clientConn.Close()
+	defer serverConn.Close()
+
+	logger := slog.Default()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		firstReq := &ChatRequest{Type: "session.create"}
+		srv.handleChatConnection(serverConn, firstReq, sm, logger)
+	}()
+
+	enc := json.NewEncoder(clientConn)
+	dec := json.NewDecoder(clientConn)
+
+	var created ChatEvent
+	if err := dec.Decode(&created); err != nil {
+		t.Fatalf("decode session.created: %v", err)
+	}
+
+	if err := enc.Encode(ChatRequest{Type: "message", SessionID: created.SessionID, Content: "/review some code"}); err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+
+	var ev ChatEvent
+	if err := dec.Decode(&ev); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if ev.Type != "done" {
+		t.Fatalf("expected done event, got %s: %+v", ev.Type, ev)
+	}
+	if ev.Content == "" {
+		t.Error("expected non-empty skill response")
 	}
 }

--- a/pkg/daemon/chat_handler_test.go
+++ b/pkg/daemon/chat_handler_test.go
@@ -294,6 +294,62 @@ func TestSlashCommandCleanResetsSession(t *testing.T) {
 	}
 }
 
+func TestCommandsList(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	srv := newTestServer(ctx)
+
+	sm := &SessionManager{
+		chatCfg: &session.Config{
+			Provider:    blockingProvider{},
+			WelcomeText: "hello",
+		},
+		sessions: make(map[string]*ManagedSession),
+	}
+
+	clientConn, serverConn := net.Pipe()
+	defer clientConn.Close()
+	defer serverConn.Close()
+
+	logger := slog.Default()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		firstReq := &ChatRequest{Type: "commands.list"}
+		srv.handleChatConnection(serverConn, firstReq, sm, logger)
+	}()
+
+	dec := json.NewDecoder(clientConn)
+
+	var ev ChatEvent
+	if err := dec.Decode(&ev); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if ev.Type != "commands.list" {
+		t.Fatalf("expected commands.list event, got %s: %+v", ev.Type, ev)
+	}
+	if len(ev.Commands) == 0 {
+		t.Fatal("expected non-empty commands list")
+	}
+
+	// The test server has /help registered; verify it's in the list.
+	found := false
+	for _, cmd := range ev.Commands {
+		if cmd.Name == "help" {
+			found = true
+			if cmd.Description == "" {
+				t.Error("expected non-empty description for /help")
+			}
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected /help in commands list, got %+v", ev.Commands)
+	}
+}
+
 func TestSlashSkillCommandDispatch(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -96,6 +96,20 @@ func Run(ctx context.Context, cfg Config) error {
 		return sm.ResetSession(ctx, id)
 	})
 	cmdRegistry.Register(cleanCmd)
+	statusCmd := command.NewStatusCommand(func(_ context.Context, id string) (command.StatusInfo, error) {
+		sess := sm.Get(id)
+		if sess == nil {
+			return command.StatusInfo{}, fmt.Errorf("session not found: %s", id)
+		}
+		return command.StatusInfo{
+			SessionID:    sess.ID,
+			MessageCount: len(sess.Messages),
+			Provider:     cfg.Provider,
+			Model:        cfg.Model,
+			Uptime:       time.Since(sess.createdAt),
+		}, nil
+	})
+	cmdRegistry.Register(statusCmd)
 	srv.SetCommands(cmdRegistry)
 
 	// --- Cron scheduler (declared early so status handler can access it) ---

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -13,6 +13,7 @@ import (
 
 	"wildgecu/pkg/agent"
 	"wildgecu/pkg/chat/telegram"
+	"wildgecu/pkg/command"
 	"wildgecu/pkg/cron"
 	"wildgecu/pkg/home"
 	"wildgecu/pkg/provider/factory"
@@ -86,6 +87,12 @@ func Run(ctx context.Context, cfg Config) error {
 	}
 	srv.SetSessions(sm)
 	logger.Info("session manager ready")
+
+	// --- Slash command registry ---
+	cmdRegistry := command.NewRegistry(h.SkillsDir())
+	helpCmd := command.NewHelpCommand(cmdRegistry)
+	cmdRegistry.Register(helpCmd)
+	srv.SetCommands(cmdRegistry)
 
 	// --- Cron scheduler (declared early so status handler can access it) ---
 
@@ -203,7 +210,7 @@ func Run(ctx context.Context, cfg Config) error {
 
 	// --- Telegram bot ---
 	if cfg.TelegramToken != "" && sm != nil {
-		tgBridge, err := telegram.New(cfg.TelegramToken, sm, tgAuth)
+		tgBridge, err := telegram.New(cfg.TelegramToken, sm, tgAuth, cmdRegistry)
 		if err != nil {
 			logger.Warn("telegram bot disabled", "error", err)
 		} else {

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -92,6 +92,10 @@ func Run(ctx context.Context, cfg Config) error {
 	cmdRegistry := command.NewRegistry(h.SkillsDir())
 	helpCmd := command.NewHelpCommand(cmdRegistry)
 	cmdRegistry.Register(helpCmd)
+	cleanCmd := command.NewCleanCommand(func(ctx context.Context, id string) (string, error) {
+		return sm.ResetSession(ctx, id)
+	})
+	cmdRegistry.Register(cleanCmd)
 	srv.SetCommands(cmdRegistry)
 
 	// --- Cron scheduler (declared early so status handler can access it) ---

--- a/pkg/daemon/sessions.go
+++ b/pkg/daemon/sessions.go
@@ -114,6 +114,25 @@ func (sm *SessionManager) Close(ctx context.Context, id string) {
 }
 
 
+// Reset closes the given session (with finalize) and creates a fresh one.
+func (sm *SessionManager) Reset(ctx context.Context, id string) (*ManagedSession, error) {
+	if sm.Get(id) == nil {
+		return nil, fmt.Errorf("session not found: %s", id)
+	}
+	sm.Close(ctx, id)
+	return sm.Create(), nil
+}
+
+// ResetSession resets a session and returns the new session ID.
+// This satisfies the telegram.SessionProvider interface.
+func (sm *SessionManager) ResetSession(ctx context.Context, id string) (string, error) {
+	sess, err := sm.Reset(ctx, id)
+	if err != nil {
+		return "", err
+	}
+	return sess.ID, nil
+}
+
 // Interrupt cancels the current turn if one is running.
 func (sm *SessionManager) Interrupt(id string) {
 	sess := sm.Get(id)

--- a/pkg/daemon/sessions.go
+++ b/pkg/daemon/sessions.go
@@ -163,6 +163,20 @@ type OnInformFunc func(message string)
 // RunTurnStream runs a single conversational turn with streaming callbacks.
 // It locks the session for the duration.
 func (sm *SessionManager) RunTurnStream(ctx context.Context, id, input string, onChunk OnChunkFunc, onToolCall OnToolCallFunc, onInform OnInformFunc) (string, error) {
+	return sm.runTurnInternal(ctx, id, input, "", onChunk, onToolCall, onInform)
+}
+
+// RunSkillTurnStream runs a streaming LLM turn with skill content injected as
+// additional system context. The skill content is appended to the session's
+// system prompt, and userInput becomes the user message.
+func (sm *SessionManager) RunSkillTurnStream(ctx context.Context, id, skillContent, userInput string, onChunk OnChunkFunc, onToolCall OnToolCallFunc, onInform OnInformFunc) (string, error) {
+	return sm.runTurnInternal(ctx, id, userInput, skillContent, onChunk, onToolCall, onInform)
+}
+
+// runTurnInternal is the shared implementation for RunTurnStream and
+// RunSkillTurnStream. When extraSystem is non-empty it is appended to the
+// session's system prompt.
+func (sm *SessionManager) runTurnInternal(ctx context.Context, id, input, extraSystem string, onChunk OnChunkFunc, onToolCall OnToolCallFunc, onInform OnInformFunc) (string, error) {
 	sess := sm.Get(id)
 	if sess == nil {
 		return "", fmt.Errorf("session not found: %s", id)
@@ -188,6 +202,9 @@ func (sm *SessionManager) RunTurnStream(ctx context.Context, id, input string, o
 		baseCfg = sess.cfg
 	}
 	cfg := *baseCfg
+	if extraSystem != "" {
+		cfg.SystemPrompt = cfg.SystemPrompt + "\n\n" + extraSystem
+	}
 	cfg.OnToolCall = func(tc provider.ToolCall) {
 		if onToolCall != nil {
 			onToolCall(tc.Name, formatToolArgs(tc.Args, 100))
@@ -213,6 +230,24 @@ func (sm *SessionManager) RunTurnStream(ctx context.Context, id, input string, o
 
 	sess.Messages = updated
 	return resp.Message.Content, nil
+}
+
+// RunSkillTurnStreamRaw is like RunSkillTurnStream but uses plain function
+// types, making it usable as a telegram.SessionProvider method.
+func (sm *SessionManager) RunSkillTurnStreamRaw(ctx context.Context, id, skillContent, userInput string, onChunk func(string), onToolCall func(string, string), onInform func(string)) (string, error) {
+	var chunkCb OnChunkFunc
+	if onChunk != nil {
+		chunkCb = OnChunkFunc(onChunk)
+	}
+	var toolCb OnToolCallFunc
+	if onToolCall != nil {
+		toolCb = OnToolCallFunc(onToolCall)
+	}
+	var informCb OnInformFunc
+	if onInform != nil {
+		informCb = OnInformFunc(onInform)
+	}
+	return sm.RunSkillTurnStream(ctx, id, skillContent, userInput, chunkCb, toolCb, informCb)
 }
 
 // RunTurnStreamRaw is like RunTurnStream but uses plain function types instead

--- a/pkg/daemon/sessions_test.go
+++ b/pkg/daemon/sessions_test.go
@@ -1,0 +1,119 @@
+package daemon
+
+import (
+	"context"
+	"testing"
+
+	"wildgecu/pkg/agent"
+	"wildgecu/pkg/home"
+	"wildgecu/pkg/provider"
+	"wildgecu/pkg/session"
+)
+
+// fakeProvider returns a canned response without calling any real LLM.
+type fakeProvider struct{}
+
+func (fakeProvider) Generate(_ context.Context, _ *provider.GenerateParams) (*provider.Response, error) {
+	return &provider.Response{
+		Message: provider.Message{Role: "assistant", Content: "ok"},
+	}, nil
+}
+
+func newTestSessionManager(t *testing.T) *SessionManager {
+	t.Helper()
+	h, err := home.New(t.TempDir())
+	if err != nil {
+		t.Fatalf("home.New: %v", err)
+	}
+	return &SessionManager{
+		agentCfg: agent.Config{
+			Provider: fakeProvider{},
+			Home:     h,
+		},
+		chatCfg: &session.Config{
+			Provider:    fakeProvider{},
+			WelcomeText: "hello",
+		},
+		sessions: make(map[string]*ManagedSession),
+	}
+}
+
+func TestReset(t *testing.T) {
+	t.Run("returns new session with different ID", func(t *testing.T) {
+		sm := newTestSessionManager(t)
+		old := sm.Create()
+		oldID := old.ID
+
+		// Add a message so the old session is non-empty.
+		old.Messages = append(old.Messages, provider.Message{Role: "user", Content: "hi"})
+
+		newSess, err := sm.Reset(context.Background(), oldID)
+		if err != nil {
+			t.Fatalf("Reset() error: %v", err)
+		}
+		if newSess.ID == oldID {
+			t.Error("expected new session to have a different ID")
+		}
+	})
+
+	t.Run("old session is removed", func(t *testing.T) {
+		sm := newTestSessionManager(t)
+		old := sm.Create()
+		oldID := old.ID
+
+		_, err := sm.Reset(context.Background(), oldID)
+		if err != nil {
+			t.Fatalf("Reset() error: %v", err)
+		}
+		if sm.Get(oldID) != nil {
+			t.Error("expected old session to be removed")
+		}
+	})
+
+	t.Run("new session is retrievable", func(t *testing.T) {
+		sm := newTestSessionManager(t)
+		old := sm.Create()
+
+		newSess, err := sm.Reset(context.Background(), old.ID)
+		if err != nil {
+			t.Fatalf("Reset() error: %v", err)
+		}
+		if sm.Get(newSess.ID) == nil {
+			t.Error("expected new session to be retrievable")
+		}
+	})
+
+	t.Run("new session has fresh messages", func(t *testing.T) {
+		sm := newTestSessionManager(t)
+		sm.chatCfg.InitialMessages = []provider.Message{
+			{Role: "system", Content: "You are helpful."},
+		}
+		old := sm.Create()
+		// Simulate conversation history.
+		old.Messages = append(old.Messages,
+			provider.Message{Role: "user", Content: "hello"},
+			provider.Message{Role: "assistant", Content: "hi there"},
+		)
+
+		newSess, err := sm.Reset(context.Background(), old.ID)
+		if err != nil {
+			t.Fatalf("Reset() error: %v", err)
+		}
+		// New session should only have the initial messages, not the old conversation.
+		if len(newSess.Messages) != 1 {
+			t.Errorf("expected 1 initial message, got %d", len(newSess.Messages))
+		}
+		if newSess.Messages[0].Content != "You are helpful." {
+			t.Errorf("expected initial system message, got %q", newSess.Messages[0].Content)
+		}
+	})
+
+	t.Run("error on unknown session", func(t *testing.T) {
+		sm := newTestSessionManager(t)
+
+		_, err := sm.Reset(context.Background(), "nonexistent")
+		if err == nil {
+			t.Fatal("expected error for unknown session")
+		}
+	})
+}

--- a/pkg/daemon/sessions_test.go
+++ b/pkg/daemon/sessions_test.go
@@ -10,6 +10,25 @@ import (
 	"wildgecu/pkg/session"
 )
 
+// capturingProvider records the last system prompt and user message it received.
+type capturingProvider struct {
+	lastSystemPrompt string
+	lastUserMessage  string
+}
+
+func (p *capturingProvider) Generate(_ context.Context, params *provider.GenerateParams) (*provider.Response, error) {
+	p.lastSystemPrompt = params.SystemPrompt
+	for i := len(params.Messages) - 1; i >= 0; i-- {
+		if params.Messages[i].Role == provider.RoleUser {
+			p.lastUserMessage = params.Messages[i].Content
+			break
+		}
+	}
+	return &provider.Response{
+		Message: provider.Message{Role: "assistant", Content: "ok"},
+	}, nil
+}
+
 // fakeProvider returns a canned response without calling any real LLM.
 type fakeProvider struct{}
 
@@ -114,6 +133,77 @@ func TestReset(t *testing.T) {
 		_, err := sm.Reset(context.Background(), "nonexistent")
 		if err == nil {
 			t.Fatal("expected error for unknown session")
+		}
+	})
+}
+
+func TestRunSkillTurnStream(t *testing.T) {
+	newSMWithCapture := func(basePrompt string) (*SessionManager, *capturingProvider) {
+		cp := &capturingProvider{}
+		sm := &SessionManager{
+			chatCfg: &session.Config{
+				Provider:     cp,
+				SystemPrompt: basePrompt,
+				WelcomeText:  "hello",
+			},
+			sessions: make(map[string]*ManagedSession),
+		}
+		return sm, cp
+	}
+
+	t.Run("injects skill content into system prompt", func(t *testing.T) {
+		sm, cp := newSMWithCapture("base prompt")
+		sess := sm.Create()
+
+		if _, err := sm.RunSkillTurnStream(context.Background(), sess.ID, "skill instructions", "do the thing", nil, nil, nil); err != nil {
+			t.Fatalf("RunSkillTurnStream() error: %v", err)
+		}
+
+		want := "base prompt\n\nskill instructions"
+		if cp.lastSystemPrompt != want {
+			t.Errorf("SystemPrompt = %q, want %q", cp.lastSystemPrompt, want)
+		}
+	})
+
+	t.Run("does not modify system prompt when skill content is empty", func(t *testing.T) {
+		sm, cp := newSMWithCapture("base prompt")
+		sess := sm.Create()
+
+		if _, err := sm.RunSkillTurnStream(context.Background(), sess.ID, "", "do the thing", nil, nil, nil); err != nil {
+			t.Fatalf("RunSkillTurnStream() error: %v", err)
+		}
+
+		if cp.lastSystemPrompt != "base prompt" {
+			t.Errorf("SystemPrompt = %q, want %q", cp.lastSystemPrompt, "base prompt")
+		}
+	})
+
+	t.Run("passes user input as user message", func(t *testing.T) {
+		sm, cp := newSMWithCapture("base prompt")
+		sess := sm.Create()
+
+		if _, err := sm.RunSkillTurnStream(context.Background(), sess.ID, "skill instructions", "review main.go", nil, nil, nil); err != nil {
+			t.Fatalf("RunSkillTurnStream() error: %v", err)
+		}
+
+		if cp.lastUserMessage != "review main.go" {
+			t.Errorf("lastUserMessage = %q, want %q", cp.lastUserMessage, "review main.go")
+		}
+	})
+
+	t.Run("skill content does not persist to subsequent turns", func(t *testing.T) {
+		sm, cp := newSMWithCapture("base prompt")
+		sess := sm.Create()
+
+		if _, err := sm.RunSkillTurnStream(context.Background(), sess.ID, "skill instructions", "do the thing", nil, nil, nil); err != nil {
+			t.Fatalf("RunSkillTurnStream() error: %v", err)
+		}
+		if _, err := sm.RunTurnStream(context.Background(), sess.ID, "follow up", nil, nil, nil); err != nil {
+			t.Fatalf("RunTurnStream() error: %v", err)
+		}
+
+		if cp.lastSystemPrompt != "base prompt" {
+			t.Errorf("after regular turn, SystemPrompt = %q, want %q", cp.lastSystemPrompt, "base prompt")
 		}
 	})
 }

--- a/pkg/daemon/socket.go
+++ b/pkg/daemon/socket.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"strings"
 	"sync"
+
+	"wildgecu/pkg/command"
 )
 
 // CommandHandler processes a daemon request and returns a response.
@@ -19,6 +21,7 @@ type SocketServer struct {
 	listener net.Listener
 	handlers map[string]CommandHandler
 	sessions *SessionManager
+	commands *command.Registry
 	logger   *slog.Logger
 	path     string
 	ctx      context.Context
@@ -55,6 +58,11 @@ func NewSocketServer(logger *slog.Logger) (*SocketServer, error) {
 // SetSessions configures the session manager for NDJSON chat connections.
 func (s *SocketServer) SetSessions(sm *SessionManager) {
 	s.sessions = sm
+}
+
+// SetCommands configures the slash command registry for NDJSON chat connections.
+func (s *SocketServer) SetCommands(r *command.Registry) {
+	s.commands = r
 }
 
 // Handle registers a handler for the given command name.

--- a/pkg/daemon/socket.go
+++ b/pkg/daemon/socket.go
@@ -128,7 +128,7 @@ func (s *SocketServer) handleConnection(_ context.Context, conn net.Conn) {
 		return
 	}
 
-	if strings.HasPrefix(probe.Type, "session.") || probe.Type == "message" {
+	if strings.HasPrefix(probe.Type, "session.") || probe.Type == "message" || probe.Type == "commands.list" {
 		// NDJSON chat protocol.
 		if s.sessions == nil {
 			encoder := json.NewEncoder(conn)


### PR DESCRIPTION
## Summary

- Add a command registry with parser supporting `/help`, `/clean`, and `/status` slash commands
- Implement `/clean` to reset the current session and `/status` to display session info
- Add skill commands with streaming LLM execution for extensible command handling
- Implement TUI dropdown autocomplete for slash commands with keyboard navigation
- Register commands with Telegram via `setMyCommands` for native autocomplete support

Closes #16