### PR TITLE
Add tool call count and skills loaded to /status command

### DIFF
--- a/pkg/command/status.go
+++ b/pkg/command/status.go
@@ -10,6 +10,8 @@ import (
 type StatusInfo struct {
 	SessionID    string
 	MessageCount int
+	ToolCalls    int
+	SkillsLoaded int
 	Provider     string
 	Model        string
 	Uptime       time.Duration
@@ -41,7 +43,7 @@ func (c *StatusCommand) Execute(ctx context.Context, _ string) (string, error) {
 		return "", fmt.Errorf("get session status: %w", err)
 	}
 	return fmt.Sprintf(
-		"Session:  %s\nMessages: %d\nProvider: %s\nModel:    %s\nUptime:   %s",
-		info.SessionID, info.MessageCount, info.Provider, info.Model, info.Uptime,
+		"Session:  %s\nMessages: %d\nTools:    %d\nSkills:   %d\nProvider: %s\nModel:    %s\nUptime:   %s",
+		info.SessionID, info.MessageCount, info.ToolCalls, info.SkillsLoaded, info.Provider, info.Model, info.Uptime,
 	), nil
 }

--- a/pkg/command/status_test.go
+++ b/pkg/command/status_test.go
@@ -14,6 +14,8 @@ func TestStatusCommand(t *testing.T) {
 			return StatusInfo{
 				SessionID:    "sess-abc-123",
 				MessageCount: 42,
+				ToolCalls:    7,
+				SkillsLoaded: 2,
 				Provider:     "openai",
 				Model:        "gpt-4o",
 				Uptime:       3*time.Hour + 15*time.Minute,
@@ -26,7 +28,7 @@ func TestStatusCommand(t *testing.T) {
 			t.Fatalf("Execute() error: %v", err)
 		}
 
-		for _, want := range []string{"sess-abc-123", "42", "openai", "gpt-4o", "3h15m"} {
+		for _, want := range []string{"sess-abc-123", "42", "7", "2", "openai", "gpt-4o", "3h15m"} {
 			if !strings.Contains(result, want) {
 				t.Errorf("expected result to contain %q, got:\n%s", want, result)
 			}

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -101,9 +101,23 @@ func Run(ctx context.Context, cfg Config) error {
 		if sess == nil {
 			return command.StatusInfo{}, fmt.Errorf("session not found: %s", id)
 		}
+		var toolCalls int
+		uniqueSkills := make(map[string]struct{})
+		for _, msg := range sess.Messages {
+			toolCalls += len(msg.ToolCalls)
+			for _, tc := range msg.ToolCalls {
+				if tc.Name == "read_skill" {
+					if name, ok := tc.Args["name"].(string); ok {
+						uniqueSkills[name] = struct{}{}
+					}
+				}
+			}
+		}
 		return command.StatusInfo{
 			SessionID:    sess.ID,
 			MessageCount: len(sess.Messages),
+			ToolCalls:    toolCalls,
+			SkillsLoaded: len(uniqueSkills),
 			Provider:     cfg.Provider,
 			Model:        cfg.Model,
 			Uptime:       time.Since(sess.createdAt),


### PR DESCRIPTION
Extend StatusInfo with ToolCalls (total tool invocations) and
SkillsLoaded (unique skills read via read_skill) fields, computed
by scanning session messages. Helps users understand session activity.

https://claude.ai/code/session_01399iF54j6i7EdqsMPTrcYA