### PR TITLE
feat(tool): add spawn_agent tool for ephemeral subagents

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ WildGecu is a modular AI agent framework in Go. It provides a reusable foundatio
 - **Skills** — a plugin system with lazy-loaded Markdown-based definitions and YAML frontmatter
 - **Cron jobs** — an in-process scheduler with isolated sessions, powered by gocron
 - **Parallel tool calling** — concurrent execution of independent tool calls within the agent loop
+- **Ephemeral subagents** — delegate subtasks to child agents with isolated context, optional model override, and tool subsetting via the `spawn_agent` tool
 - **Telegram bridge** — daemon-based chat via Telegram bot
 - **Self-update** — the agent can update its own binary at runtime
 - **Background daemon** — long-running process with health checks, IPC socket, and system service support
@@ -58,7 +59,28 @@ wildgecu init:                          wildgecu chat / code:
 └──────┬──────────┘      └──────┬──────────┘         └──────┬──────────┘
        │                        │                           │
        ▼                        └─────────────┬─────────────┘
-    Chat TUI                                  ▼
+    Chat TUI                                  │
+                                              ▼
+                                     ┌─────────────────┐
+                                     │   Agent loop     │
+                                     │  (generate →     │
+                                     │   tool calls →   │
+                                     │   generate)      │
+                                     └──────┬──────────┘
+                                            │
+                              ┌─────────────┼─────────────┐
+                              │  spawn_agent (optional)   │
+                              ▼             ▼             ▼
+                        ┌──────────┐ ┌──────────┐ ┌──────────┐
+                        │ Subagent │ │ Subagent │ │ Subagent │
+                        │ (model A)│ │ (model B)│ │ (model A)│
+                        │ isolated │ │ isolated │ │ isolated │
+                        │ context  │ │ context  │ │ context  │
+                        └────┬─────┘ └────┬─────┘ └────┬─────┘
+                             │            │            │
+                             └────────────┼────────────┘
+                              text results│back to parent
+                                          ▼
                                      ┌─────────────────┐
                                      │ Memory curation │
                                      │ → .wildgecu/    │
@@ -227,6 +249,47 @@ When reviewing Go code, focus on...
 
 The agent loads skills dynamically via the `load_skill` tool during conversation.
 
+## Ephemeral subagents
+
+The agent can delegate subtasks to **ephemeral subagents** via the `spawn_agent` tool. A subagent is a short-lived child agent that runs in isolation — it receives a prompt, executes a full agent loop (generate → tool calls → generate), and returns a single text result to the parent. No SOUL, no MEMORY, no finalization. It lives within the parent session and is discarded when done.
+
+### Why subagents?
+
+- **Cheaper models for simple work** — delegate straightforward tasks (summarization, formatting, lookups) to a faster/cheaper model while keeping the expensive model for complex reasoning.
+- **Focused context** — a subagent gets a clean context window with an optional custom system prompt, so intermediate steps don't clutter the parent's conversation.
+- **Parallel research** — the parent can spawn multiple subagents simultaneously as concurrent tool calls, gathering information from different angles and synthesizing results.
+- **Tool restriction** — give a research subagent read-only tools, or give a coding subagent file-write access while restricting everything else.
+
+### `spawn_agent` tool
+
+The tool is available in both chat and code modes. Parameters:
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `prompt` | Yes | The user message to send to the child agent |
+| `system_prompt` | No | Custom system prompt. If omitted, uses a minimal default |
+| `model` | No | Provider/model reference (e.g., `gemini/gemini-2.0-flash`). If omitted, inherits the parent's model |
+| `tools` | No | List of tool names the child can use. If omitted, inherits all parent tools except `spawn_agent` |
+
+**Recursion prevention:** subagents cannot spawn further subagents. The `spawn_agent` tool is excluded from every child agent's tool set.
+
+### Example usage (from the agent's perspective)
+
+The agent decides to delegate autonomously — the user doesn't need to manage subagents directly:
+
+```
+# Agent spawns a focused researcher with a cheaper model
+spawn_agent(
+  prompt: "List all exported functions in pkg/provider/tool/registry.go",
+  model: "gemini/gemini-2.0-flash",
+  tools: ["bash", "read_file", "list_files"]
+)
+
+# Agent spawns multiple subagents in parallel for research
+spawn_agent(prompt: "Summarize the README.md", model: "gemini/gemini-2.0-flash")
+spawn_agent(prompt: "List all TODO comments in the codebase", tools: ["bash"])
+```
+
 ## Configuration
 
 WildGecu uses a unified home directory at `~/.wildgecu/` for all global state. Override it with `--home`:
@@ -364,7 +427,7 @@ wildgecu.go                  # Entry point → cmd.Execute()
 │
 ├── pkg/                     # Core domain packages
 │   ├── agent/               # Agent orchestration (Prepare, Finalize, bootstrap, memory, prompts)
-│   │   └── tools/           # Tool suites (general, exec, files, skills)
+│   │   └── tools/           # Tool suites (general, exec, files, skills, subagent)
 │   ├── provider/            # LLM provider abstraction
 │   │   ├── tool/            # Type-safe tool framework (Tool, Registry, schema generation)
 │   │   ├── factory/         # Provider factory
@@ -388,6 +451,7 @@ wildgecu.go                  # Entry point → cmd.Execute()
 - **Project-local `.wildgecu/`** — Per-project identity files (`SOUL.md`, `MEMORY.md`, `USER.md`) stay in the working directory, separate from global daemon state.
 - **Home abstraction** — File operations are abstracted behind an interface (`FSHome` for disk, `MemHome` for tests), keeping the agent logic testable.
 - **Parallel tool calling** — Independent tool calls within a single agent turn are executed concurrently for lower latency.
+- **Ephemeral subagents** — The `spawn_agent` tool lets the agent delegate subtasks to isolated child agents with optional model override and tool subsetting. Subagents are stateless and cannot spawn further subagents.
 
 ## Providers
 

--- a/pkg/agent/AGENT.md
+++ b/pkg/agent/AGENT.md
@@ -24,6 +24,18 @@ You have access to a `load_skill` tool. Skills are domain-specific modules that 
 
 You have access to an `inform_user` tool. Use it to send progress updates to the user during long-running, multi-step tasks without interrupting your workflow. Call it when starting a significant step or when progress is worth reporting — don't call it for every minor action.
 
+### Subagents
+
+You have access to a `spawn_agent` tool that delegates a subtask to an ephemeral child agent. The child runs in isolation — its own context window, optional custom system prompt, and optional model override — and returns a single text result to you. Use it when:
+
+- **The subtask is self-contained** — it can be fully described in a prompt and doesn't need your conversation history.
+- **A cheaper/faster model suffices** — simple lookups, summarization, or formatting don't need your current model. Specify a lighter `model` to save cost and latency.
+- **You want parallel research** — spawn multiple subagents simultaneously to gather information from different angles, then synthesize their results.
+- **You want a focused persona** — provide a `system_prompt` to give the child specialized behavior (e.g., "you are a code reviewer") without changing your own identity.
+- **You want to restrict tools** — pass a `tools` list to limit what the child can do (e.g., read-only tools for a research task).
+
+**Do not use subagents when:** the task needs your conversation context, requires back-and-forth with the user, or is too simple to justify the overhead of spawning.
+
 ## Behavioral guidelines
 
 - **Follow the user's language.** If they write in Italian, respond in Italian. If they switch, follow.

--- a/pkg/agent/CODE_AGENT.md
+++ b/pkg/agent/CODE_AGENT.md
@@ -28,6 +28,17 @@ Use `bash` only for running commands: build, test, git, install, compile, lint �
 
 You have access to an `inform_user` tool. Use it to send progress updates to the user during long-running, multi-step tasks without interrupting your workflow. Call it when starting a significant step or when progress is worth reporting — don't call it for every minor action.
 
+## Subagents
+
+You have access to a `spawn_agent` tool that delegates a subtask to an ephemeral child agent. The child runs in isolation with its own context and returns a single text result. Use it when:
+
+- **Parallel research** — spawn multiple subagents to explore different parts of the codebase simultaneously (e.g., one reads tests while another reads the implementation).
+- **Cheaper model for simple work** — delegate straightforward tasks like listing files, summarizing code, or formatting output to a faster/cheaper `model`.
+- **Focused code review** — provide a `system_prompt` like "you are a Go code reviewer" to get specialized feedback on a file without polluting your context.
+- **Restricted tool access** — pass a `tools` list to limit a subagent to read-only tools (e.g., `["read_file", "list_files", "bash"]`) for safe exploration.
+
+**Do not use subagents when:** the task requires your conversation context, needs multi-step edits that depend on each other, or is trivial enough to do directly.
+
 ## Behavioral guidelines
 
 - **Follow the user's language.** If they write in Italian, respond in Italian.

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -14,13 +14,18 @@ import (
 	"wildgecu/x/debug"
 )
 
+// ProviderResolver resolves a provider.Provider from a model identifier.
+// It is typically backed by a container.Container.
+type ProviderResolver func(ctx context.Context, model string) (provider.Provider, error)
+
 // Config holds the configuration needed to run the agent.
 type Config struct {
-	Provider     provider.Provider
-	Home         *home.Home
-	Workspace    *home.Home
-	TelegramAuth *auth.Store // nil when Telegram auth is not configured
-	Debug        bool
+	Provider        provider.Provider
+	Home            *home.Home
+	Workspace       *home.Home
+	TelegramAuth    *auth.Store        // nil when Telegram auth is not configured
+	ResolveProvider ProviderResolver   // nil when model override is not supported
+	Debug           bool
 }
 
 // Prepare setup the agent environment, loads soul/memory and returns a session configuration.
@@ -55,6 +60,7 @@ func Prepare(ctx context.Context, cfg Config) (*session.Config, *debug.Logger, e
 	registry.Add(tools.SkillTools(skillsDir))
 	registry.Add(tools.InformTools())
 	registry.Add(tools.TelegramTools(cfg.TelegramAuth))
+	registry.Add(tools.SubagentTools(cfg.Provider, registry, tools.ProviderResolver(cfg.ResolveProvider)))
 	systemPrompt := BuildSystemPrompt(cfg.Workspace, soulContent, memoryContent)
 	if dbg != nil {
 		dbg.SystemPrompt(systemPrompt)
@@ -121,6 +127,7 @@ func PrepareCode(ctx context.Context, cfg Config, workDir string) (*session.Conf
 	registry.Add(tools.SkillTools(skillsDir))
 	registry.Add(tools.InformTools())
 	registry.Add(tools.TelegramTools(cfg.TelegramAuth))
+	registry.Add(tools.SubagentTools(cfg.Provider, registry, tools.ProviderResolver(cfg.ResolveProvider)))
 	systemPrompt := BuildCodeSystemPrompt(cfg.Workspace, soulContent, memoryContent, workDir)
 	if dbg != nil {
 		dbg.SystemPrompt(systemPrompt)

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -14,17 +14,13 @@ import (
 	"wildgecu/x/debug"
 )
 
-// ProviderResolver resolves a provider.Provider from a model identifier.
-// It is typically backed by a container.Container.
-type ProviderResolver func(ctx context.Context, model string) (provider.Provider, error)
-
 // Config holds the configuration needed to run the agent.
 type Config struct {
 	Provider        provider.Provider
 	Home            *home.Home
 	Workspace       *home.Home
-	TelegramAuth    *auth.Store        // nil when Telegram auth is not configured
-	ResolveProvider ProviderResolver   // nil when model override is not supported
+	TelegramAuth    *auth.Store             // nil when Telegram auth is not configured
+	ResolveProvider tools.ProviderResolver  // nil when model override is not supported
 	Debug           bool
 }
 
@@ -60,7 +56,7 @@ func Prepare(ctx context.Context, cfg Config) (*session.Config, *debug.Logger, e
 	registry.Add(tools.SkillTools(skillsDir))
 	registry.Add(tools.InformTools())
 	registry.Add(tools.TelegramTools(cfg.TelegramAuth))
-	registry.Add(tools.SubagentTools(cfg.Provider, registry, tools.ProviderResolver(cfg.ResolveProvider)))
+	registry.Add(tools.SubagentTools(cfg.Provider, registry, cfg.ResolveProvider))
 	systemPrompt := BuildSystemPrompt(cfg.Workspace, soulContent, memoryContent)
 	if dbg != nil {
 		dbg.SystemPrompt(systemPrompt)
@@ -127,7 +123,7 @@ func PrepareCode(ctx context.Context, cfg Config, workDir string) (*session.Conf
 	registry.Add(tools.SkillTools(skillsDir))
 	registry.Add(tools.InformTools())
 	registry.Add(tools.TelegramTools(cfg.TelegramAuth))
-	registry.Add(tools.SubagentTools(cfg.Provider, registry, tools.ProviderResolver(cfg.ResolveProvider)))
+	registry.Add(tools.SubagentTools(cfg.Provider, registry, cfg.ResolveProvider))
 	systemPrompt := BuildCodeSystemPrompt(cfg.Workspace, soulContent, memoryContent, workDir)
 	if dbg != nil {
 		dbg.SystemPrompt(systemPrompt)

--- a/pkg/agent/tools/subagent.go
+++ b/pkg/agent/tools/subagent.go
@@ -1,0 +1,94 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+
+	"wildgecu/pkg/provider"
+	"wildgecu/pkg/provider/tool"
+)
+
+const spawnAgentName = "spawn_agent"
+
+const defaultSubagentSystemPrompt = "You are a helpful assistant. Complete the given task and provide a clear response."
+
+type spawnAgentInput struct {
+	Prompt       string `json:"prompt" description:"The task or question for the subagent"`
+	SystemPrompt string `json:"system_prompt,omitempty" description:"Optional system prompt for the subagent"`
+	Model        string `json:"model,omitempty" description:"Optional model override (e.g. openai/gpt-4o-mini)"`
+}
+
+type spawnAgentOutput struct {
+	Result string `json:"result"`
+}
+
+// ProviderResolver resolves a provider.Provider from a model identifier.
+type ProviderResolver func(ctx context.Context, model string) (provider.Provider, error)
+
+// SubagentTools returns the spawn_agent tool. The tool uses defaultProvider for
+// LLM calls unless a model override is given and resolve is non-nil.
+// reg is the parent's tool registry; the child inherits all tools except spawn_agent.
+func SubagentTools(defaultProvider provider.Provider, reg *tool.Registry, resolve ProviderResolver) []tool.Tool {
+	return []tool.Tool{newSpawnAgentTool(defaultProvider, reg, resolve)}
+}
+
+func newSpawnAgentTool(defaultProvider provider.Provider, reg *tool.Registry, resolve ProviderResolver) tool.Tool {
+	return tool.NewTool(spawnAgentName,
+		"Spawn an ephemeral subagent to handle a task. The subagent runs in isolation with its own context and returns only the final text response.",
+		func(ctx context.Context, in spawnAgentInput) (spawnAgentOutput, error) {
+			p := defaultProvider
+			if in.Model != "" && resolve != nil {
+				resolved, err := resolve(ctx, in.Model)
+				if err != nil {
+					return spawnAgentOutput{}, fmt.Errorf("resolve model %q: %w", in.Model, err)
+				}
+				p = resolved
+			}
+
+			systemPrompt := defaultSubagentSystemPrompt
+			if in.SystemPrompt != "" {
+				systemPrompt = in.SystemPrompt
+			}
+
+			// Build child tools: all parent tools minus spawn_agent.
+			var childToolDefs []provider.Tool
+			var childNames []string
+			if reg != nil {
+				for _, t := range reg.Tools() {
+					if t.Name != spawnAgentName {
+						childToolDefs = append(childToolDefs, t)
+						childNames = append(childNames, t.Name)
+					}
+				}
+			}
+
+			var executor provider.ToolExecutor
+			if reg != nil && len(childNames) > 0 {
+				executor = reg.Subset(childNames).Executor()
+			}
+
+			messages := []provider.Message{
+				{Role: provider.RoleUser, Content: in.Prompt},
+			}
+
+			msgs, _, err := provider.RunAgentLoop(
+				ctx, p, systemPrompt, messages, childToolDefs,
+				executor, nil, nil,
+			)
+			if err != nil {
+				return spawnAgentOutput{}, err
+			}
+
+			// Extract final text from last model message.
+			var result string
+			for i := len(msgs) - 1; i >= 0; i-- {
+				if msgs[i].Role == provider.RoleModel && msgs[i].Content != "" {
+					result = msgs[i].Content
+					break
+				}
+			}
+
+			return spawnAgentOutput{Result: result}, nil
+		},
+	)
+}

--- a/pkg/agent/tools/subagent.go
+++ b/pkg/agent/tools/subagent.go
@@ -28,7 +28,8 @@ type ProviderResolver func(ctx context.Context, model string) (provider.Provider
 
 // SubagentTools returns the spawn_agent tool. The tool uses defaultProvider for
 // LLM calls unless a model override is given and resolve is non-nil.
-// reg is the parent's tool registry; the child inherits all tools except spawn_agent.
+// reg is the parent's tool registry; by default the child inherits all parent tools
+// except spawn_agent, but the caller can pass an explicit tools list to restrict the set.
 func SubagentTools(defaultProvider provider.Provider, reg *tool.Registry, resolve ProviderResolver) []tool.Tool {
 	return []tool.Tool{newSpawnAgentTool(defaultProvider, reg, resolve)}
 }

--- a/pkg/agent/tools/subagent.go
+++ b/pkg/agent/tools/subagent.go
@@ -13,9 +13,10 @@ const spawnAgentName = "spawn_agent"
 const defaultSubagentSystemPrompt = "You are a helpful assistant. Complete the given task and provide a clear response."
 
 type spawnAgentInput struct {
-	Prompt       string `json:"prompt" description:"The task or question for the subagent"`
-	SystemPrompt string `json:"system_prompt,omitempty" description:"Optional system prompt for the subagent"`
-	Model        string `json:"model,omitempty" description:"Optional model override (e.g. openai/gpt-4o-mini)"`
+	Prompt       string   `json:"prompt" description:"The task or question for the subagent"`
+	SystemPrompt string   `json:"system_prompt,omitempty" description:"Optional system prompt for the subagent"`
+	Model        string   `json:"model,omitempty" description:"Optional model override (e.g. openai/gpt-4o-mini)"`
+	Tools        []string `json:"tools,omitempty" description:"Optional list of tool names the subagent can use. When omitted, inherits all parent tools except spawn_agent."`
 }
 
 type spawnAgentOutput struct {
@@ -50,21 +51,30 @@ func newSpawnAgentTool(defaultProvider provider.Provider, reg *tool.Registry, re
 				systemPrompt = in.SystemPrompt
 			}
 
-			// Build child tools: all parent tools minus spawn_agent.
-			var childToolDefs []provider.Tool
-			var childNames []string
+			// Build child tools: use explicit list if provided,
+			// otherwise inherit all parent tools minus spawn_agent.
+			var childReg *tool.Registry
 			if reg != nil {
-				for _, t := range reg.Tools() {
-					if t.Name != spawnAgentName {
-						childToolDefs = append(childToolDefs, t)
-						childNames = append(childNames, t.Name)
+				if in.Tools != nil {
+					childReg = reg.Subset(in.Tools)
+				} else {
+					var childNames []string
+					for _, t := range reg.Tools() {
+						if t.Name != spawnAgentName {
+							childNames = append(childNames, t.Name)
+						}
 					}
+					childReg = reg.Subset(childNames)
 				}
 			}
 
+			var childToolDefs []provider.Tool
 			var executor provider.ToolExecutor
-			if reg != nil && len(childNames) > 0 {
-				executor = reg.Subset(childNames).Executor()
+			if childReg != nil {
+				childToolDefs = childReg.Tools()
+				if len(childToolDefs) > 0 {
+					executor = childReg.Executor()
+				}
 			}
 
 			messages := []provider.Message{

--- a/pkg/agent/tools/subagent_test.go
+++ b/pkg/agent/tools/subagent_test.go
@@ -1,0 +1,262 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"wildgecu/pkg/provider"
+	"wildgecu/pkg/provider/tool"
+)
+
+// mockProvider records Generate calls and returns a canned response.
+type mockProvider struct {
+	calls    []provider.GenerateParams
+	response *provider.Response
+}
+
+func (m *mockProvider) Generate(_ context.Context, params *provider.GenerateParams) (*provider.Response, error) {
+	m.calls = append(m.calls, *params)
+	return m.response, nil
+}
+
+func newMockProvider(content string) *mockProvider {
+	return &mockProvider{
+		response: &provider.Response{
+			Message: provider.Message{Role: provider.RoleModel, Content: content},
+		},
+	}
+}
+
+func TestSubagentTools(t *testing.T) {
+	t.Run("returns one tool named spawn_agent", func(t *testing.T) {
+		tools := SubagentTools(nil, nil, nil)
+		if len(tools) != 1 {
+			t.Fatalf("expected 1 tool, got %d", len(tools))
+		}
+		if got := tools[0].Definition().Name; got != "spawn_agent" {
+			t.Errorf("expected tool name spawn_agent, got %q", got)
+		}
+	})
+
+	t.Run("schema has prompt required and optional fields", func(t *testing.T) {
+		tl := SubagentTools(nil, nil, nil)[0]
+		def := tl.Definition()
+		params := def.Parameters
+
+		props, hasProps := params["properties"].(map[string]any)
+		if !hasProps {
+			t.Fatal("expected properties in schema")
+		}
+		if _, found := props["prompt"]; !found {
+			t.Error("expected prompt in properties")
+		}
+		if _, found := props["system_prompt"]; !found {
+			t.Error("expected system_prompt in properties")
+		}
+		if _, found := props["model"]; !found {
+			t.Error("expected model in properties")
+		}
+
+		required, hasReq := params["required"].([]any)
+		if !hasReq {
+			t.Fatal("expected required in schema")
+		}
+		if len(required) != 1 || required[0] != "prompt" {
+			t.Errorf("expected required=[prompt], got %v", required)
+		}
+	})
+}
+
+func TestSpawnAgent(t *testing.T) {
+	t.Run("forwards prompt to provider", func(t *testing.T) {
+		mp := newMockProvider("result")
+		reg := tool.NewRegistry()
+		tl := SubagentTools(mp, reg, nil)[0]
+
+		result, err := tl.Execute(context.Background(), map[string]any{
+			"prompt": "summarize this",
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if len(mp.calls) != 1 {
+			t.Fatalf("expected 1 Generate call, got %d", len(mp.calls))
+		}
+
+		call := mp.calls[0]
+		if len(call.Messages) != 1 {
+			t.Fatalf("expected 1 message, got %d", len(call.Messages))
+		}
+		if call.Messages[0].Role != provider.RoleUser {
+			t.Errorf("expected user role, got %q", call.Messages[0].Role)
+		}
+		if call.Messages[0].Content != "summarize this" {
+			t.Errorf("expected prompt %q, got %q", "summarize this", call.Messages[0].Content)
+		}
+
+		var out spawnAgentOutput
+		if err := json.Unmarshal([]byte(result), &out); err != nil {
+			t.Fatalf("unmarshal result: %v", err)
+		}
+		if out.Result != "result" {
+			t.Errorf("expected result %q, got %q", "result", out.Result)
+		}
+	})
+
+	t.Run("uses default system prompt when omitted", func(t *testing.T) {
+		mp := newMockProvider("ok")
+		reg := tool.NewRegistry()
+		tl := SubagentTools(mp, reg, nil)[0]
+
+		_, err := tl.Execute(context.Background(), map[string]any{
+			"prompt": "hello",
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if mp.calls[0].SystemPrompt != defaultSubagentSystemPrompt {
+			t.Errorf("expected default system prompt, got %q", mp.calls[0].SystemPrompt)
+		}
+	})
+
+	t.Run("uses custom system prompt when provided", func(t *testing.T) {
+		mp := newMockProvider("ok")
+		reg := tool.NewRegistry()
+		tl := SubagentTools(mp, reg, nil)[0]
+
+		_, err := tl.Execute(context.Background(), map[string]any{
+			"prompt":        "hello",
+			"system_prompt": "You are a translator.",
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if mp.calls[0].SystemPrompt != "You are a translator." {
+			t.Errorf("expected custom system prompt, got %q", mp.calls[0].SystemPrompt)
+		}
+	})
+
+	t.Run("uses default provider when model omitted", func(t *testing.T) {
+		defaultMP := newMockProvider("from default")
+		reg := tool.NewRegistry()
+		tl := SubagentTools(defaultMP, reg, nil)[0]
+
+		result, err := tl.Execute(context.Background(), map[string]any{
+			"prompt": "hello",
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if len(defaultMP.calls) != 1 {
+			t.Fatalf("expected default provider to be called, got %d calls", len(defaultMP.calls))
+		}
+
+		var out spawnAgentOutput
+		json.Unmarshal([]byte(result), &out)
+		if out.Result != "from default" {
+			t.Errorf("expected %q, got %q", "from default", out.Result)
+		}
+	})
+
+	t.Run("resolves model via resolver when model provided", func(t *testing.T) {
+		defaultMP := newMockProvider("from default")
+		overrideMP := newMockProvider("from override")
+		reg := tool.NewRegistry()
+
+		resolver := func(_ context.Context, model string) (provider.Provider, error) {
+			if model == "openai/gpt-4o-mini" {
+				return overrideMP, nil
+			}
+			return nil, nil
+		}
+
+		tl := SubagentTools(defaultMP, reg, resolver)[0]
+		result, err := tl.Execute(context.Background(), map[string]any{
+			"prompt": "hello",
+			"model":  "openai/gpt-4o-mini",
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if len(defaultMP.calls) != 0 {
+			t.Error("expected default provider NOT to be called")
+		}
+		if len(overrideMP.calls) != 1 {
+			t.Fatalf("expected override provider to be called once, got %d", len(overrideMP.calls))
+		}
+
+		var out spawnAgentOutput
+		json.Unmarshal([]byte(result), &out)
+		if out.Result != "from override" {
+			t.Errorf("expected %q, got %q", "from override", out.Result)
+		}
+	})
+
+	t.Run("child excludes spawn_agent from tools", func(t *testing.T) {
+		mp := newMockProvider("ok")
+
+		// Create a registry with some tools including spawn_agent itself.
+		dummyTool := tool.NewTool("dummy_tool", "A dummy tool",
+			func(ctx context.Context, in struct{}) (struct{}, error) {
+				return struct{}{}, nil
+			},
+		)
+		spawnTool := SubagentTools(mp, nil, nil)[0]
+
+		reg := tool.NewRegistry(dummyTool, spawnTool)
+		tl := SubagentTools(mp, reg, nil)[0]
+
+		_, err := tl.Execute(context.Background(), map[string]any{
+			"prompt": "hello",
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		call := mp.calls[0]
+		for _, t2 := range call.Tools {
+			if t2.Name == "spawn_agent" {
+				t.Error("spawn_agent should be excluded from child tools")
+			}
+		}
+
+		// Verify dummy_tool IS present.
+		found := false
+		for _, t2 := range call.Tools {
+			if t2.Name == "dummy_tool" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Error("expected dummy_tool in child tools")
+		}
+	})
+
+	t.Run("returns final text from last model message", func(t *testing.T) {
+		mp := newMockProvider("final answer")
+		reg := tool.NewRegistry()
+		tl := SubagentTools(mp, reg, nil)[0]
+
+		result, err := tl.Execute(context.Background(), map[string]any{
+			"prompt": "question",
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		var out spawnAgentOutput
+		if err := json.Unmarshal([]byte(result), &out); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if out.Result != "final answer" {
+			t.Errorf("expected %q, got %q", "final answer", out.Result)
+		}
+	})
+}

--- a/pkg/agent/tools/subagent_test.go
+++ b/pkg/agent/tools/subagent_test.go
@@ -57,6 +57,9 @@ func TestSubagentTools(t *testing.T) {
 		if _, found := props["model"]; !found {
 			t.Error("expected model in properties")
 		}
+		if _, found := props["tools"]; !found {
+			t.Error("expected tools in properties")
+		}
 
 		required, hasReq := params["required"].([]any)
 		if !hasReq {
@@ -236,6 +239,105 @@ func TestSpawnAgent(t *testing.T) {
 		}
 		if !found {
 			t.Error("expected dummy_tool in child tools")
+		}
+	})
+
+	t.Run("explicit tools list restricts child tools", func(t *testing.T) {
+		mp := newMockProvider("ok")
+
+		dummyA := tool.NewTool("tool_a", "Tool A",
+			func(ctx context.Context, in struct{}) (struct{}, error) {
+				return struct{}{}, nil
+			},
+		)
+		dummyB := tool.NewTool("tool_b", "Tool B",
+			func(ctx context.Context, in struct{}) (struct{}, error) {
+				return struct{}{}, nil
+			},
+		)
+		dummyC := tool.NewTool("tool_c", "Tool C",
+			func(ctx context.Context, in struct{}) (struct{}, error) {
+				return struct{}{}, nil
+			},
+		)
+
+		reg := tool.NewRegistry(dummyA, dummyB, dummyC)
+		tl := SubagentTools(mp, reg, nil)[0]
+
+		_, err := tl.Execute(context.Background(), map[string]any{
+			"prompt": "hello",
+			"tools":  []any{"tool_a", "tool_c"},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		call := mp.calls[0]
+		names := map[string]bool{}
+		for _, td := range call.Tools {
+			names[td.Name] = true
+		}
+		if !names["tool_a"] {
+			t.Error("expected tool_a in child tools")
+		}
+		if !names["tool_c"] {
+			t.Error("expected tool_c in child tools")
+		}
+		if names["tool_b"] {
+			t.Error("tool_b should be excluded from child tools")
+		}
+	})
+
+	t.Run("empty tools list gives child no tools", func(t *testing.T) {
+		mp := newMockProvider("ok")
+
+		dummyA := tool.NewTool("tool_a", "Tool A",
+			func(ctx context.Context, in struct{}) (struct{}, error) {
+				return struct{}{}, nil
+			},
+		)
+		reg := tool.NewRegistry(dummyA)
+		tl := SubagentTools(mp, reg, nil)[0]
+
+		_, err := tl.Execute(context.Background(), map[string]any{
+			"prompt": "hello",
+			"tools":  []any{},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		call := mp.calls[0]
+		if len(call.Tools) != 0 {
+			t.Errorf("expected no tools, got %d", len(call.Tools))
+		}
+	})
+
+	t.Run("unknown tool names are ignored", func(t *testing.T) {
+		mp := newMockProvider("ok")
+
+		dummyA := tool.NewTool("tool_a", "Tool A",
+			func(ctx context.Context, in struct{}) (struct{}, error) {
+				return struct{}{}, nil
+			},
+		)
+		reg := tool.NewRegistry(dummyA)
+		tl := SubagentTools(mp, reg, nil)[0]
+
+		_, err := tl.Execute(context.Background(), map[string]any{
+			"prompt": "hello",
+			"tools":  []any{"tool_a", "nonexistent_tool"},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		call := mp.calls[0]
+		if len(call.Tools) != 1 {
+			t.Fatalf("expected 1 tool, got %d", len(call.Tools))
+		}
+		if call.Tools[0].Name != "tool_a" {
+			t.Errorf("expected tool_a, got %q", call.Tools[0].Name)
 		}
 	})
 

--- a/pkg/agent/tools/subagent_test.go
+++ b/pkg/agent/tools/subagent_test.go
@@ -3,7 +3,10 @@ package tools
 import (
 	"context"
 	"encoding/json"
+	"sort"
+	"sync"
 	"testing"
+	"time"
 
 	"wildgecu/pkg/provider"
 	"wildgecu/pkg/provider/tool"
@@ -26,6 +29,15 @@ func newMockProvider(content string) *mockProvider {
 			Message: provider.Message{Role: provider.RoleModel, Content: content},
 		},
 	}
+}
+
+// funcProvider delegates Generate to an arbitrary function.
+type funcProvider struct {
+	fn func(context.Context, *provider.GenerateParams) (*provider.Response, error)
+}
+
+func (p *funcProvider) Generate(ctx context.Context, params *provider.GenerateParams) (*provider.Response, error) {
+	return p.fn(ctx, params)
 }
 
 func TestSubagentTools(t *testing.T) {
@@ -359,6 +371,103 @@ func TestSpawnAgent(t *testing.T) {
 		}
 		if out.Result != "final answer" {
 			t.Errorf("expected %q, got %q", "final answer", out.Result)
+		}
+	})
+
+	t.Run("parallel spawn_agent calls execute concurrently", func(t *testing.T) {
+		const agentDelay = 100 * time.Millisecond
+
+		// Track when each child agent starts to verify concurrency.
+		var mu sync.Mutex
+		var childStarts []time.Time
+
+		child := &funcProvider{fn: func(_ context.Context, params *provider.GenerateParams) (*provider.Response, error) {
+			mu.Lock()
+			childStarts = append(childStarts, time.Now())
+			mu.Unlock()
+			time.Sleep(agentDelay)
+			return &provider.Response{
+				Message: provider.Message{
+					Role:    provider.RoleModel,
+					Content: "done: " + params.Messages[0].Content,
+				},
+			}, nil
+		}}
+
+		reg := tool.NewRegistry()
+		reg.Add(SubagentTools(child, reg, nil))
+
+		// Parent provider: first call returns 3 spawn_agent tool calls,
+		// second call returns final text.
+		var parentCall int
+		parent := &funcProvider{fn: func(_ context.Context, _ *provider.GenerateParams) (*provider.Response, error) {
+			parentCall++
+			if parentCall == 1 {
+				return &provider.Response{
+					Message: provider.Message{
+						Role: provider.RoleModel,
+						ToolCalls: []provider.ToolCall{
+							{Name: "spawn_agent", ID: "a", Args: map[string]any{"prompt": "task 0"}},
+							{Name: "spawn_agent", ID: "b", Args: map[string]any{"prompt": "task 1"}},
+							{Name: "spawn_agent", ID: "c", Args: map[string]any{"prompt": "task 2"}},
+						},
+					},
+				}, nil
+			}
+			return &provider.Response{
+				Message: provider.Message{Role: provider.RoleModel, Content: "all done"},
+			}, nil
+		}}
+
+		before := time.Now()
+		msgs, _, err := provider.RunAgentLoop(
+			context.Background(), parent, "sys",
+			[]provider.Message{{Role: provider.RoleUser, Content: "run tasks"}},
+			reg.Tools(), reg.Executor(), nil, nil,
+		)
+		elapsed := time.Since(before)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// Verify concurrency: if sequential, total >= 300ms; if concurrent, ~100ms.
+		if elapsed >= 3*agentDelay {
+			t.Errorf("expected concurrent execution (<%v), took %v", 3*agentDelay, elapsed)
+		}
+
+		// Child start times should be near-simultaneous.
+		mu.Lock()
+		starts := append([]time.Time{}, childStarts...)
+		mu.Unlock()
+		if len(starts) != 3 {
+			t.Fatalf("expected 3 child starts, got %d", len(starts))
+		}
+		sort.Slice(starts, func(i, j int) bool { return starts[i].Before(starts[j]) })
+		if gap := starts[2].Sub(starts[0]); gap > 50*time.Millisecond {
+			t.Errorf("child agents not concurrent: start time spread = %v, want < 50ms", gap)
+		}
+
+		// Verify all results are correctly returned to the parent.
+		// Expected messages: user, model(tool calls), 3×tool, model(final).
+		var results []string
+		for _, m := range msgs {
+			if m.Role == provider.RoleTool {
+				var out spawnAgentOutput
+				if err := json.Unmarshal([]byte(m.Content), &out); err != nil {
+					t.Fatalf("unmarshal tool result: %v", err)
+				}
+				results = append(results, out.Result)
+			}
+		}
+		sort.Strings(results)
+		want := []string{"done: task 0", "done: task 1", "done: task 2"}
+		if len(results) != len(want) {
+			t.Fatalf("expected %d results, got %d", len(want), len(results))
+		}
+		for i := range want {
+			if results[i] != want[i] {
+				t.Errorf("result[%d] = %q, want %q", i, results[i], want[i])
+			}
 		}
 	})
 }

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -300,10 +300,11 @@ func initSessionManager(ctx context.Context, cfg Config, h *home.Home, tgAuth *a
 	}
 
 	agentCfg := agent.Config{
-		Provider:     p,
-		Home:         h,
-		Workspace:    h, // daemon uses global home as workspace
-		TelegramAuth: tgAuth,
+		Provider:        p,
+		Home:            h,
+		Workspace:       h, // daemon uses global home as workspace
+		TelegramAuth:    tgAuth,
+		ResolveProvider: cfg.Container.Get,
 	}
 
 	return NewSessionManager(ctx, agentCfg, cfg.Container)

--- a/pkg/provider/tool/registry.go
+++ b/pkg/provider/tool/registry.go
@@ -40,6 +40,23 @@ func (r *Registry) Tools() []provider.Tool {
 	return out
 }
 
+// Subset returns a new Registry containing only the named tools,
+// preserving their original insertion order. Unknown names are silently ignored.
+func (r *Registry) Subset(names []string) *Registry {
+	want := make(map[string]struct{}, len(names))
+	for _, n := range names {
+		want[n] = struct{}{}
+	}
+	sub := &Registry{tools: make(map[string]Tool)}
+	for _, name := range r.order {
+		if _, ok := want[name]; ok {
+			sub.tools[name] = r.tools[name]
+			sub.order = append(sub.order, name)
+		}
+	}
+	return sub
+}
+
 // Executor returns a provider.ToolExecutor that dispatches by tool name.
 func (r *Registry) Executor() provider.ToolExecutor {
 	return func(ctx context.Context, tc provider.ToolCall) (string, error) {

--- a/pkg/provider/tool/tool_test.go
+++ b/pkg/provider/tool/tool_test.go
@@ -244,4 +244,154 @@ func TestRegistry(t *testing.T) {
 			t.Fatalf("unexpected result: %s", result)
 		}
 	})
+
+	t.Run("SubsetHappyPath", func(t *testing.T) {
+		alpha := NewTool("alpha", "first tool",
+			func(ctx context.Context, in EchoInput) (EchoOutput, error) {
+				return EchoOutput{Echo: "alpha:" + in.Message}, nil
+			},
+		)
+		beta := NewTool("beta", "second tool",
+			func(ctx context.Context, in EchoInput) (EchoOutput, error) {
+				return EchoOutput{Echo: "beta:" + in.Message}, nil
+			},
+		)
+		gamma := NewTool("gamma", "third tool",
+			func(ctx context.Context, in EchoInput) (EchoOutput, error) {
+				return EchoOutput{Echo: "gamma:" + in.Message}, nil
+			},
+		)
+
+		reg := NewRegistry(alpha, beta, gamma)
+		sub := reg.Subset([]string{"gamma", "alpha"})
+
+		tools := sub.Tools()
+		if len(tools) != 2 {
+			t.Fatalf("expected 2 tools, got %d", len(tools))
+		}
+		// Insertion order from original registry: alpha before gamma
+		if tools[0].Name != "alpha" {
+			t.Fatalf("tools[0] = %q, want alpha", tools[0].Name)
+		}
+		if tools[1].Name != "gamma" {
+			t.Fatalf("tools[1] = %q, want gamma", tools[1].Name)
+		}
+	})
+
+	t.Run("SubsetUnknownNames", func(t *testing.T) {
+		echo := NewTool("echo", "Echoes",
+			func(ctx context.Context, in EchoInput) (EchoOutput, error) {
+				return EchoOutput{Echo: in.Message}, nil
+			},
+		)
+
+		reg := NewRegistry(echo)
+		sub := reg.Subset([]string{"echo", "nonexistent", "also_missing"})
+
+		tools := sub.Tools()
+		if len(tools) != 1 {
+			t.Fatalf("expected 1 tool, got %d", len(tools))
+		}
+		if tools[0].Name != "echo" {
+			t.Fatalf("tool name = %q, want echo", tools[0].Name)
+		}
+	})
+
+	t.Run("SubsetEmpty", func(t *testing.T) {
+		echo := NewTool("echo", "Echoes",
+			func(ctx context.Context, in EchoInput) (EchoOutput, error) {
+				return EchoOutput{Echo: in.Message}, nil
+			},
+		)
+
+		reg := NewRegistry(echo)
+		sub := reg.Subset([]string{})
+
+		tools := sub.Tools()
+		if len(tools) != 0 {
+			t.Fatalf("expected 0 tools, got %d", len(tools))
+		}
+
+		executor := sub.Executor()
+		result, err := executor(context.Background(), provider.ToolCall{Name: "echo", Args: map[string]any{}})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result != `{"error": "unknown tool: echo"}` {
+			t.Fatalf("unexpected result: %s", result)
+		}
+	})
+
+	t.Run("SubsetFullSet", func(t *testing.T) {
+		alpha := NewTool("alpha", "first",
+			func(ctx context.Context, in EchoInput) (EchoOutput, error) {
+				return EchoOutput{Echo: "a"}, nil
+			},
+		)
+		beta := NewTool("beta", "second",
+			func(ctx context.Context, in EchoInput) (EchoOutput, error) {
+				return EchoOutput{Echo: "b"}, nil
+			},
+		)
+
+		reg := NewRegistry(alpha, beta)
+		sub := reg.Subset([]string{"alpha", "beta"})
+
+		tools := sub.Tools()
+		if len(tools) != 2 {
+			t.Fatalf("expected 2 tools, got %d", len(tools))
+		}
+		if tools[0].Name != "alpha" {
+			t.Fatalf("tools[0] = %q, want alpha", tools[0].Name)
+		}
+		if tools[1].Name != "beta" {
+			t.Fatalf("tools[1] = %q, want beta", tools[1].Name)
+		}
+	})
+
+	t.Run("SubsetExecutorDispatch", func(t *testing.T) {
+		alpha := NewTool("alpha", "first",
+			func(ctx context.Context, in EchoInput) (EchoOutput, error) {
+				return EchoOutput{Echo: "alpha:" + in.Message}, nil
+			},
+		)
+		beta := NewTool("beta", "second",
+			func(ctx context.Context, in EchoInput) (EchoOutput, error) {
+				return EchoOutput{Echo: "beta:" + in.Message}, nil
+			},
+		)
+
+		reg := NewRegistry(alpha, beta)
+		sub := reg.Subset([]string{"alpha"})
+
+		executor := sub.Executor()
+
+		// Included tool works
+		result, err := executor(context.Background(), provider.ToolCall{
+			Name: "alpha",
+			Args: map[string]any{"message": "hi"},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		var out EchoOutput
+		if unmarshalErr := json.Unmarshal([]byte(result), &out); unmarshalErr != nil {
+			t.Fatalf("unmarshal: %v", unmarshalErr)
+		}
+		if out.Echo != "alpha:hi" {
+			t.Fatalf("echo = %q, want alpha:hi", out.Echo)
+		}
+
+		// Excluded tool returns error
+		result, err = executor(context.Background(), provider.ToolCall{
+			Name: "beta",
+			Args: map[string]any{"message": "hi"},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result != `{"error": "unknown tool: beta"}` {
+			t.Fatalf("unexpected result: %s", result)
+		}
+	})
 }


### PR DESCRIPTION
## Summary

- Add `spawn_agent` tool that lets the main agent delegate subtasks to ephemeral subagents running in isolated goroutines with their own context and conversation history
- Add `Registry.Subset` method to filter available tools by name, allowing subagents to operate with a restricted toolset
- Support an optional `tools` parameter on `spawn_agent` so the caller can specify which tools the subagent has access to
- Update `AGENT.md`, `CODE_AGENT.md`, and `README.md` with documentation for the new subagent capability
- Add comprehensive tests covering subagent execution, tool filtering, parallel spawning, and error handling

Closes #33