### PR TITLE
feat(tui): surface subagent tool calls with agent label

### DIFF
--- a/pkg/agent/tools/subagent.go
+++ b/pkg/agent/tools/subagent.go
@@ -14,6 +14,7 @@ const defaultSubagentSystemPrompt = "You are a helpful assistant. Complete the g
 
 type spawnAgentInput struct {
 	Prompt       string   `json:"prompt" description:"The task or question for the subagent"`
+	Name         string   `json:"name,omitempty" description:"Short identifier for this subagent (e.g. researcher, summarizer). Shown in tool-call output so the user can tell which subagent is acting."`
 	SystemPrompt string   `json:"system_prompt,omitempty" description:"Optional system prompt for the subagent"`
 	Model        string   `json:"model,omitempty" description:"Optional model override (e.g. openai/gpt-4o-mini)"`
 	Tools        []string `json:"tools,omitempty" description:"Optional list of tool names the subagent can use. When omitted, inherits all parent tools except spawn_agent."`
@@ -79,11 +80,15 @@ func newSpawnAgentTool(defaultProvider provider.Provider, reg *tool.Registry, re
 			}
 
 			// Extract parent's onToolCall from context and wrap it to
-			// inject "subagent" as the agent label.
+			// inject the agent name as the agent label.
+			agentName := in.Name
+			if agentName == "" {
+				agentName = "subagent"
+			}
 			var childOnToolCall provider.ToolCallCallback
 			if parentCb := provider.GetToolCallCallback(ctx); parentCb != nil {
 				childOnToolCall = func(name, args, _ string) {
-					parentCb(name, args, "subagent")
+					parentCb(name, args, agentName)
 				}
 			}
 

--- a/pkg/agent/tools/subagent.go
+++ b/pkg/agent/tools/subagent.go
@@ -78,13 +78,22 @@ func newSpawnAgentTool(defaultProvider provider.Provider, reg *tool.Registry, re
 				}
 			}
 
+			// Extract parent's onToolCall from context and wrap it to
+			// inject "subagent" as the agent label.
+			var childOnToolCall provider.ToolCallCallback
+			if parentCb := provider.GetToolCallCallback(ctx); parentCb != nil {
+				childOnToolCall = func(name, args, _ string) {
+					parentCb(name, args, "subagent")
+				}
+			}
+
 			messages := []provider.Message{
 				{Role: provider.RoleUser, Content: in.Prompt},
 			}
 
 			msgs, _, err := provider.RunAgentLoop(
 				ctx, p, systemPrompt, messages, childToolDefs,
-				executor, nil, nil,
+				executor, childOnToolCall, nil,
 			)
 			if err != nil {
 				return spawnAgentOutput{}, err

--- a/pkg/agent/tools/subagent_test.go
+++ b/pkg/agent/tools/subagent_test.go
@@ -72,6 +72,9 @@ func TestSubagentTools(t *testing.T) {
 		if _, found := props["tools"]; !found {
 			t.Error("expected tools in properties")
 		}
+		if _, found := props["name"]; !found {
+			t.Error("expected name in properties")
+		}
 
 		required, hasReq := params["required"].([]any)
 		if !hasReq {
@@ -429,6 +432,106 @@ func TestSpawnAgent(t *testing.T) {
 		}
 	})
 
+	t.Run("propagates custom name through callback", func(t *testing.T) {
+		var callNum int
+		childProvider := &funcProvider{fn: func(_ context.Context, params *provider.GenerateParams) (*provider.Response, error) {
+			callNum++
+			if callNum == 1 {
+				return &provider.Response{
+					Message: provider.Message{
+						Role: provider.RoleModel,
+						ToolCalls: []provider.ToolCall{
+							{Name: "dummy_tool", ID: "t1", Args: map[string]any{"key": "val"}},
+						},
+					},
+				}, nil
+			}
+			return &provider.Response{
+				Message: provider.Message{Role: provider.RoleModel, Content: "done"},
+			}, nil
+		}}
+
+		dummyTool := tool.NewTool("dummy_tool", "A dummy tool",
+			func(ctx context.Context, in struct {
+				Key string `json:"key"`
+			}) (struct{}, error) {
+				return struct{}{}, nil
+			},
+		)
+		reg := tool.NewRegistry(dummyTool)
+		tl := SubagentTools(childProvider, reg, nil)[0]
+
+		type callRecord struct {
+			name, args, agent string
+		}
+		var recorded []callRecord
+		ctx := provider.WithToolCallCallback(context.Background(), func(name, args, agent string) {
+			recorded = append(recorded, callRecord{name, args, agent})
+		})
+
+		_, err := tl.Execute(ctx, map[string]any{"prompt": "do it", "name": "researcher"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if len(recorded) != 1 {
+			t.Fatalf("expected 1 callback invocation, got %d", len(recorded))
+		}
+		if recorded[0].agent != "researcher" {
+			t.Errorf("agent = %q, want %q", recorded[0].agent, "researcher")
+		}
+	})
+
+	t.Run("defaults to subagent when name is omitted", func(t *testing.T) {
+		var callNum int
+		childProvider := &funcProvider{fn: func(_ context.Context, params *provider.GenerateParams) (*provider.Response, error) {
+			callNum++
+			if callNum == 1 {
+				return &provider.Response{
+					Message: provider.Message{
+						Role: provider.RoleModel,
+						ToolCalls: []provider.ToolCall{
+							{Name: "dummy_tool", ID: "t1", Args: map[string]any{"key": "val"}},
+						},
+					},
+				}, nil
+			}
+			return &provider.Response{
+				Message: provider.Message{Role: provider.RoleModel, Content: "done"},
+			}, nil
+		}}
+
+		dummyTool := tool.NewTool("dummy_tool", "A dummy tool",
+			func(ctx context.Context, in struct {
+				Key string `json:"key"`
+			}) (struct{}, error) {
+				return struct{}{}, nil
+			},
+		)
+		reg := tool.NewRegistry(dummyTool)
+		tl := SubagentTools(childProvider, reg, nil)[0]
+
+		type callRecord struct {
+			name, args, agent string
+		}
+		var recorded []callRecord
+		ctx := provider.WithToolCallCallback(context.Background(), func(name, args, agent string) {
+			recorded = append(recorded, callRecord{name, args, agent})
+		})
+
+		_, err := tl.Execute(ctx, map[string]any{"prompt": "do it"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if len(recorded) != 1 {
+			t.Fatalf("expected 1 callback invocation, got %d", len(recorded))
+		}
+		if recorded[0].agent != "subagent" {
+			t.Errorf("agent = %q, want %q", recorded[0].agent, "subagent")
+		}
+	})
+
 	t.Run("runs without error when no parent callback in context", func(t *testing.T) {
 		mp := newMockProvider("ok")
 		reg := tool.NewRegistry()
@@ -440,6 +543,99 @@ func TestSpawnAgent(t *testing.T) {
 		})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("concurrent subagents with different names show correct labels", func(t *testing.T) {
+		// Each child provider invokes a tool, so the parent callback fires
+		// with the correct agent name for each subagent.
+		child := &funcProvider{fn: func(_ context.Context, params *provider.GenerateParams) (*provider.Response, error) {
+			// First call: invoke dummy_tool; second call: return text.
+			if len(params.Messages) == 1 {
+				return &provider.Response{
+					Message: provider.Message{
+						Role: provider.RoleModel,
+						ToolCalls: []provider.ToolCall{
+							{Name: "dummy_tool", ID: "t1", Args: map[string]any{}},
+						},
+					},
+				}, nil
+			}
+			return &provider.Response{
+				Message: provider.Message{Role: provider.RoleModel, Content: "done"},
+			}, nil
+		}}
+
+		dummyTool := tool.NewTool("dummy_tool", "A dummy tool",
+			func(ctx context.Context, in struct{}) (struct{}, error) {
+				return struct{}{}, nil
+			},
+		)
+		reg := tool.NewRegistry(dummyTool)
+		reg.Add(SubagentTools(child, reg, nil))
+
+		// Parent provider issues 3 spawn_agent calls with different names.
+		var parentCall int
+		parent := &funcProvider{fn: func(_ context.Context, _ *provider.GenerateParams) (*provider.Response, error) {
+			parentCall++
+			if parentCall == 1 {
+				return &provider.Response{
+					Message: provider.Message{
+						Role: provider.RoleModel,
+						ToolCalls: []provider.ToolCall{
+							{Name: "spawn_agent", ID: "a", Args: map[string]any{"prompt": "task 0", "name": "researcher"}},
+							{Name: "spawn_agent", ID: "b", Args: map[string]any{"prompt": "task 1", "name": "summarizer"}},
+							{Name: "spawn_agent", ID: "c", Args: map[string]any{"prompt": "task 2"}},
+						},
+					},
+				}, nil
+			}
+			return &provider.Response{
+				Message: provider.Message{Role: provider.RoleModel, Content: "all done"},
+			}, nil
+		}}
+
+		type callRecord struct {
+			name, agent string
+		}
+		var mu sync.Mutex
+		var recorded []callRecord
+		onToolCall := func(name, args, agent string) {
+			mu.Lock()
+			recorded = append(recorded, callRecord{name, agent})
+			mu.Unlock()
+		}
+
+		ctx := provider.WithToolCallCallback(context.Background(), onToolCall)
+		_, _, err := provider.RunAgentLoop(
+			ctx, parent, "sys",
+			[]provider.Message{{Role: provider.RoleUser, Content: "run tasks"}},
+			reg.Tools(), reg.Executor(), onToolCall, nil,
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// Collect agent labels from callback records for dummy_tool calls
+		// (spawn_agent itself also fires callbacks, filter to child tool calls).
+		mu.Lock()
+		defer mu.Unlock()
+
+		agentNames := map[string]bool{}
+		for _, r := range recorded {
+			if r.name == "dummy_tool" {
+				agentNames[r.agent] = true
+			}
+		}
+
+		if !agentNames["researcher"] {
+			t.Error("expected callback with agent=researcher")
+		}
+		if !agentNames["summarizer"] {
+			t.Error("expected callback with agent=summarizer")
+		}
+		if !agentNames["subagent"] {
+			t.Error("expected callback with agent=subagent (default for unnamed)")
 		}
 	})
 

--- a/pkg/agent/tools/subagent_test.go
+++ b/pkg/agent/tools/subagent_test.go
@@ -374,6 +374,75 @@ func TestSpawnAgent(t *testing.T) {
 		}
 	})
 
+	t.Run("propagates tool call callback with agent=subagent", func(t *testing.T) {
+		// Create a provider that makes a tool call, then returns text.
+		var callNum int
+		childProvider := &funcProvider{fn: func(_ context.Context, params *provider.GenerateParams) (*provider.Response, error) {
+			callNum++
+			if callNum == 1 {
+				return &provider.Response{
+					Message: provider.Message{
+						Role: provider.RoleModel,
+						ToolCalls: []provider.ToolCall{
+							{Name: "dummy_tool", ID: "t1", Args: map[string]any{"key": "val"}},
+						},
+					},
+				}, nil
+			}
+			return &provider.Response{
+				Message: provider.Message{Role: provider.RoleModel, Content: "done"},
+			}, nil
+		}}
+
+		dummyTool := tool.NewTool("dummy_tool", "A dummy tool",
+			func(ctx context.Context, in struct {
+				Key string `json:"key"`
+			}) (struct{}, error) {
+				return struct{}{}, nil
+			},
+		)
+		reg := tool.NewRegistry(dummyTool)
+		tl := SubagentTools(childProvider, reg, nil)[0]
+
+		// Set parent callback in context.
+		type callRecord struct {
+			name, args, agent string
+		}
+		var recorded []callRecord
+		ctx := provider.WithToolCallCallback(context.Background(), func(name, args, agent string) {
+			recorded = append(recorded, callRecord{name, args, agent})
+		})
+
+		_, err := tl.Execute(ctx, map[string]any{"prompt": "do it"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if len(recorded) != 1 {
+			t.Fatalf("expected 1 callback invocation, got %d", len(recorded))
+		}
+		if recorded[0].name != "dummy_tool" {
+			t.Errorf("name = %q, want %q", recorded[0].name, "dummy_tool")
+		}
+		if recorded[0].agent != "subagent" {
+			t.Errorf("agent = %q, want %q", recorded[0].agent, "subagent")
+		}
+	})
+
+	t.Run("runs without error when no parent callback in context", func(t *testing.T) {
+		mp := newMockProvider("ok")
+		reg := tool.NewRegistry()
+		tl := SubagentTools(mp, reg, nil)[0]
+
+		// Use bare context without any callback set.
+		_, err := tl.Execute(context.Background(), map[string]any{
+			"prompt": "hello",
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
 	t.Run("parallel spawn_agent calls execute concurrently", func(t *testing.T) {
 		const agentDelay = 100 * time.Millisecond
 

--- a/pkg/chat/telegram/commands_test.go
+++ b/pkg/chat/telegram/commands_test.go
@@ -124,10 +124,10 @@ func (m *mockBot) StopReceivingUpdates() {}
 type stubSession struct{}
 
 func (s *stubSession) CreateSession() string { return "test-session" }
-func (s *stubSession) RunTurnStreamRaw(_ context.Context, _, _ string, _ func(string), _ func(string, string), _ func(string)) (string, error) {
+func (s *stubSession) RunTurnStreamRaw(_ context.Context, _, _ string, _ func(string), _ func(string, string, string), _ func(string)) (string, error) {
 	return "ok", nil
 }
-func (s *stubSession) RunSkillTurnStreamRaw(_ context.Context, _, _, _ string, _ func(string), _ func(string, string), _ func(string)) (string, error) {
+func (s *stubSession) RunSkillTurnStreamRaw(_ context.Context, _, _, _ string, _ func(string), _ func(string, string, string), _ func(string)) (string, error) {
 	return "ok", nil
 }
 func (s *stubSession) WelcomeText() string { return "welcome" }

--- a/pkg/chat/telegram/telegram.go
+++ b/pkg/chat/telegram/telegram.go
@@ -18,8 +18,8 @@ import (
 // package does not depend on internal/daemon.
 type SessionProvider interface {
 	CreateSession() string // returns session ID
-	RunTurnStreamRaw(ctx context.Context, id string, input string, onChunk func(string), onToolCall func(string, string), onInform func(string)) (string, error)
-	RunSkillTurnStreamRaw(ctx context.Context, id, skillContent, userInput string, onChunk func(string), onToolCall func(string, string), onInform func(string)) (string, error)
+	RunTurnStreamRaw(ctx context.Context, id string, input string, onChunk func(string), onToolCall func(string, string, string), onInform func(string)) (string, error)
+	RunSkillTurnStreamRaw(ctx context.Context, id, skillContent, userInput string, onChunk func(string), onToolCall func(string, string, string), onInform func(string)) (string, error)
 	WelcomeText() string
 }
 
@@ -330,8 +330,8 @@ func (h *turnHandler) onChunk(chunk string) {
 	}
 }
 
-func (h *turnHandler) onToolCall(name, args string) {
-	h.bridge.logger.Info("telegram tool call", "name", name, "args", args)
+func (h *turnHandler) onToolCall(name, args, agent string) {
+	h.bridge.logger.Info("telegram tool call", "name", name, "args", args, "agent", agent)
 }
 
 func (h *turnHandler) onInform(message string) {

--- a/pkg/chat/tui/messages.go
+++ b/pkg/chat/tui/messages.go
@@ -15,8 +15,9 @@ type streamDoneMsg struct {
 
 // toolCallMsg is sent when the agent starts executing a tool.
 type toolCallMsg struct {
-	name string
-	args string
+	name  string
+	args  string
+	agent string
 }
 
 // agentErrorMsg is sent when the agent encounters an error.

--- a/pkg/chat/tui/tui.go
+++ b/pkg/chat/tui/tui.go
@@ -228,13 +228,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 						}
 					case "tool_call":
 						if prog.p != nil {
-							args := event.Args
-							label := event.Name
-							if args != "" {
-								label += "(" + args + ")"
-							}
-							prog.p.Send(toolCallMsg{name: event.Name, args: args})
-							_ = label
+							prog.p.Send(toolCallMsg{name: event.Name, args: event.Args, agent: event.Agent})
 						}
 					case "inform":
 						if prog.p != nil {
@@ -267,11 +261,17 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case toolCallMsg:
 		m.activeToolCall = msg.name
+		if msg.agent != "" {
+			m.activeToolCall = msg.name + " (" + msg.agent + ")"
+		}
 		n, _ := rand.Int(rand.Reader, big.NewInt(int64(len(thinkingVerbs))))
 		m.thinkingIdx = int(n.Int64())
 		label := msg.name
 		if msg.args != "" {
 			label += "(" + msg.args + ")"
+		}
+		if msg.agent != "" {
+			label = "[" + msg.agent + "] " + label
 		}
 		m.appendDisplay(toolStyle.Render("⚡ " + label))
 		return m, nil

--- a/pkg/daemon/chat_client.go
+++ b/pkg/daemon/chat_client.go
@@ -14,6 +14,7 @@ type Event struct {
 	Welcome   string        `json:"welcome,omitempty"`
 	Name      string        `json:"name,omitempty"`
 	Args      string        `json:"args,omitempty"`
+	Agent     string        `json:"agent,omitempty"`
 	Message   string        `json:"message,omitempty"`
 	Commands  []CommandInfo `json:"commands,omitempty"`
 }

--- a/pkg/daemon/chat_handler.go
+++ b/pkg/daemon/chat_handler.go
@@ -35,6 +35,7 @@ type ChatEvent struct {
 	Welcome   string        `json:"welcome,omitempty"`
 	Name      string        `json:"name,omitempty"`
 	Args      string        `json:"args,omitempty"`
+	Agent     string        `json:"agent,omitempty"`
 	Message   string        `json:"message,omitempty"`
 	Commands  []CommandInfo `json:"commands,omitempty"`
 }
@@ -181,8 +182,8 @@ func (s *SocketServer) handleSkillCommand(req *ChatRequest, runner command.Skill
 	onChunk := func(chunk string) {
 		send(ChatEvent{Type: "chunk", Content: chunk})
 	}
-	onToolCall := func(name string, args string) {
-		send(ChatEvent{Type: "tool_call", Name: name, Args: args})
+	onToolCall := func(name, args, agent string) {
+		send(ChatEvent{Type: "tool_call", Name: name, Args: args, Agent: agent})
 	}
 	onInform := func(message string) {
 		send(ChatEvent{Type: "inform", Content: message})
@@ -201,8 +202,8 @@ func (s *SocketServer) handleChatMessage(req *ChatRequest, send func(ChatEvent),
 	onChunk := func(chunk string) {
 		send(ChatEvent{Type: "chunk", Content: chunk})
 	}
-	onToolCall := func(name string, args string) {
-		send(ChatEvent{Type: "tool_call", Name: name, Args: args})
+	onToolCall := func(name, args, agent string) {
+		send(ChatEvent{Type: "tool_call", Name: name, Args: args, Agent: agent})
 	}
 	onInform := func(message string) {
 		send(ChatEvent{Type: "inform", Content: message})

--- a/pkg/daemon/sessions.go
+++ b/pkg/daemon/sessions.go
@@ -208,7 +208,8 @@ func (sm *SessionManager) WelcomeText() string {
 type OnChunkFunc func(chunk string)
 
 // OnToolCallFunc is called when the agent invokes a tool.
-type OnToolCallFunc func(name string, args string)
+// The agent parameter identifies the source (empty for the parent agent).
+type OnToolCallFunc func(name, args, agent string)
 
 // OnInformFunc is called when the agent sends a status message to the user.
 type OnInformFunc func(message string)
@@ -258,10 +259,8 @@ func (sm *SessionManager) runTurnInternal(ctx context.Context, id, input, extraS
 	if extraSystem != "" {
 		cfg.SystemPrompt = cfg.SystemPrompt + "\n\n" + extraSystem
 	}
-	cfg.OnToolCall = func(tc provider.ToolCall) {
-		if onToolCall != nil {
-			onToolCall(tc.Name, formatToolArgs(tc.Args, 100))
-		}
+	if onToolCall != nil {
+		cfg.OnToolCall = provider.ToolCallCallback(onToolCall)
 	}
 
 	chunkCb := func(chunk string) {
@@ -287,7 +286,7 @@ func (sm *SessionManager) runTurnInternal(ctx context.Context, id, input, extraS
 
 // RunSkillTurnStreamRaw is like RunSkillTurnStream but uses plain function
 // types, making it usable as a telegram.SessionProvider method.
-func (sm *SessionManager) RunSkillTurnStreamRaw(ctx context.Context, id, skillContent, userInput string, onChunk func(string), onToolCall func(string, string), onInform func(string)) (string, error) {
+func (sm *SessionManager) RunSkillTurnStreamRaw(ctx context.Context, id, skillContent, userInput string, onChunk func(string), onToolCall func(string, string, string), onInform func(string)) (string, error) {
 	var chunkCb OnChunkFunc
 	if onChunk != nil {
 		chunkCb = OnChunkFunc(onChunk)
@@ -305,7 +304,7 @@ func (sm *SessionManager) RunSkillTurnStreamRaw(ctx context.Context, id, skillCo
 
 // RunTurnStreamRaw is like RunTurnStream but uses plain function types instead
 // of named callback types, making it usable as a telegram.SessionProvider method.
-func (sm *SessionManager) RunTurnStreamRaw(ctx context.Context, id, input string, onChunk func(string), onToolCall func(string, string), onInform func(string)) (string, error) {
+func (sm *SessionManager) RunTurnStreamRaw(ctx context.Context, id, input string, onChunk func(string), onToolCall func(string, string, string), onInform func(string)) (string, error) {
 	var chunkCb OnChunkFunc
 	if onChunk != nil {
 		chunkCb = OnChunkFunc(onChunk)
@@ -321,24 +320,3 @@ func (sm *SessionManager) RunTurnStreamRaw(ctx context.Context, id, input string
 	return sm.RunTurnStream(ctx, id, input, chunkCb, toolCb, informCb)
 }
 
-// formatToolArgs formats a tool call's args map into a compact string.
-func formatToolArgs(args map[string]any, maxLen int) string {
-	if len(args) == 0 {
-		return ""
-	}
-	var parts []string
-	for k, v := range args {
-		parts = append(parts, fmt.Sprintf("%s: %v", k, v))
-	}
-	result := ""
-	for i, p := range parts {
-		if i > 0 {
-			result += ", "
-		}
-		result += p
-	}
-	if len(result) > maxLen {
-		result = result[:maxLen] + "..."
-	}
-	return result
-}

--- a/pkg/provider/agent.go
+++ b/pkg/provider/agent.go
@@ -17,11 +17,12 @@ var ErrDone = errors.New("agent loop done")
 // It returns the tool result string. Return ErrDone to stop the loop early.
 type ToolExecutor func(ctx context.Context, tc ToolCall) (string, error)
 
-// ToolCallCallback is invoked before each tool execution with the full ToolCall.
-type ToolCallCallback func(tc ToolCall)
-
 // RunAgentLoopStream is like RunAgentLoop but streams the final text response.
 func RunAgentLoopStream(ctx context.Context, p Provider, systemPrompt string, messages []Message, tools []Tool, execute ToolExecutor, onChunk StreamCallback, onToolCall ToolCallCallback, dbg *debug.Logger) ([]Message, *Response, error) {
+	if onToolCall != nil {
+		ctx = WithToolCallCallback(ctx, onToolCall)
+	}
+
 	sp, canStream := p.(StreamProvider)
 	if !canStream {
 		return RunAgentLoop(ctx, p, systemPrompt, messages, tools, execute, onToolCall, dbg)
@@ -81,6 +82,10 @@ func RunAgentLoopStream(ctx context.Context, p Provider, systemPrompt string, me
 // RunAgentLoop runs the generate-execute cycle until the model produces
 // a text response (no tool calls) or the executor signals ErrDone.
 func RunAgentLoop(ctx context.Context, p Provider, systemPrompt string, messages []Message, tools []Tool, execute ToolExecutor, onToolCall ToolCallCallback, dbg *debug.Logger) ([]Message, *Response, error) {
+	if onToolCall != nil {
+		ctx = WithToolCallCallback(ctx, onToolCall)
+	}
+
 	for {
 		dbg.GenerateRequest(len(messages), len(tools))
 
@@ -144,7 +149,7 @@ func executeToolsParallel(ctx context.Context, toolCalls []ToolCall, execute Too
 func executeOne(ctx context.Context, tc ToolCall, execute ToolExecutor, onToolCall ToolCallCallback, dbg *debug.Logger) (Message, error) {
 	dbg.ToolCall(tc.Name, tc.Args)
 	if onToolCall != nil {
-		onToolCall(tc)
+		onToolCall(tc.Name, FormatToolArgs(tc.Args, 100), "")
 	}
 
 	result, err := execute(ctx, tc)
@@ -162,4 +167,26 @@ func executeOne(ctx context.Context, tc ToolCall, execute ToolExecutor, onToolCa
 		Content:    result,
 		ToolCallID: tc.ID,
 	}, err
+}
+
+// FormatToolArgs formats a tool call's args map into a compact string.
+func FormatToolArgs(args map[string]any, maxLen int) string {
+	if len(args) == 0 {
+		return ""
+	}
+	var parts []string
+	for k, v := range args {
+		parts = append(parts, fmt.Sprintf("%s: %v", k, v))
+	}
+	result := ""
+	for i, p := range parts {
+		if i > 0 {
+			result += ", "
+		}
+		result += p
+	}
+	if len(result) > maxLen {
+		result = result[:maxLen] + "..."
+	}
+	return result
 }

--- a/pkg/provider/agent_test.go
+++ b/pkg/provider/agent_test.go
@@ -148,9 +148,9 @@ func TestExecuteToolsParallel(t *testing.T) {
 		}
 
 		var callbackCount atomic.Int32
-		callback := func(tc ToolCall) {
+		callback := ToolCallCallback(func(name, args, agent string) {
 			callbackCount.Add(1)
-		}
+		})
 
 		executor := func(ctx context.Context, tc ToolCall) (string, error) {
 			return "ok", nil

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -91,3 +91,22 @@ func GetInformFunc(ctx context.Context) InformFunc {
 	fn, _ := ctx.Value(informKey).(InformFunc)
 	return fn
 }
+
+// ToolCallCallback is invoked before each tool execution with the tool name,
+// formatted arguments, and an optional agent label (empty for the parent agent).
+type ToolCallCallback func(name, args, agent string)
+
+type toolCallCallbackKeyType struct{}
+
+var toolCallCallbackKey = toolCallCallbackKeyType{}
+
+// WithToolCallCallback returns a context carrying the given ToolCallCallback.
+func WithToolCallCallback(ctx context.Context, fn ToolCallCallback) context.Context {
+	return context.WithValue(ctx, toolCallCallbackKey, fn)
+}
+
+// GetToolCallCallback extracts the ToolCallCallback from the context, or nil.
+func GetToolCallCallback(ctx context.Context) ToolCallCallback {
+	fn, _ := ctx.Value(toolCallCallbackKey).(ToolCallCallback)
+	return fn
+}

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -1,0 +1,39 @@
+package provider
+
+import (
+	"context"
+	"testing"
+)
+
+func TestToolCallCallbackContext(t *testing.T) {
+	t.Run("round-trip", func(t *testing.T) {
+		var gotName, gotArgs, gotAgent string
+		fn := ToolCallCallback(func(name, args, agent string) {
+			gotName = name
+			gotArgs = args
+			gotAgent = agent
+		})
+		ctx := WithToolCallCallback(context.Background(), fn)
+		got := GetToolCallCallback(ctx)
+		if got == nil {
+			t.Fatal("expected non-nil ToolCallCallback from context")
+		}
+		got("my_tool", "x: 1", "subagent")
+		if gotName != "my_tool" {
+			t.Errorf("name = %q, want %q", gotName, "my_tool")
+		}
+		if gotArgs != "x: 1" {
+			t.Errorf("args = %q, want %q", gotArgs, "x: 1")
+		}
+		if gotAgent != "subagent" {
+			t.Errorf("agent = %q, want %q", gotAgent, "subagent")
+		}
+	})
+
+	t.Run("nil when not set", func(t *testing.T) {
+		got := GetToolCallCallback(context.Background())
+		if got != nil {
+			t.Error("expected nil ToolCallCallback from bare context")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- Add `ToolCallCallback` context propagation in `pkg/provider` so subagent tool calls carry an agent label through the context chain
- Introduce an optional `name` parameter to `spawn_agent`, defaulting to `"subagent"`, so each subagent can be identified in output
- Wire the callback through `RunAgentLoop`/`RunAgentLoopStream` into child agents, injecting the agent name into every tool-call event
- Update the TUI to display the agent label in both the spinner (`tool (agent)`) and the activity log (`[agent] tool(args)`)
- Extend the daemon SSE events and Telegram handler to carry the new `agent` field end-to-end
- Move `formatToolArgs` from `pkg/daemon/sessions.go` to `pkg/provider` as an exported `FormatToolArgs` helper
- Add comprehensive tests covering callback propagation, default naming, custom names, concurrent subagents, and context round-trips

Closes #51