### PR TITLE
refactor: improve default models and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,10 +99,12 @@ wildgecu init:                          wildgecu chat / code:
 ## Prerequisites
 
 - Go 1.26+
-- At least one LLM provider configured:
-  - [Google Gemini API key](https://aistudio.google.com/apikey) (default)
+- At least one LLM provider:
+  - [Google Gemini API key](https://aistudio.google.com/apikey)
   - [OpenAI API key](https://platform.openai.com/api-keys)
   - [Ollama](https://ollama.com/) running locally (no API key needed)
+  - [Mistral API key](https://console.mistral.ai/api-keys)
+  - [Regolo API key](https://regolo.ai/)
 
 ## Getting started
 
@@ -122,38 +124,72 @@ Optionally move it to a directory on your `$PATH`:
 mv wildgecu /usr/local/bin/
 ```
 
-### 2. Create the configuration directory
+### 2. Run WildGecu
 
-WildGecu stores all global state in `~/.wildgecu/`. The directory is created automatically on first run, but you can set it up manually to prepare your config and secrets beforehand:
+On first run, an interactive setup wizard guides you through provider selection, API key entry, and model choice:
 
 ```bash
-mkdir -p ~/.wildgecu
+wildgecu init
 ```
 
-### 3. Add your API keys (`.env` file)
+The wizard will:
+1. Ask you to choose a provider (Gemini, OpenAI, Ollama, Mistral, or Regolo)
+2. Prompt for your API key (if required by the provider) and validate it
+3. Let you pick a default model from a curated list or enter a custom one
+4. Write `~/.wildgecu/wildgecu.yaml` and `~/.wildgecu/.env` automatically
 
-Create a `.env` file to store your provider API keys. This keeps secrets out of the YAML config:
+After setup, the `init` command continues into the bootstrap interview where the agent asks about its name, purpose, personality, and expertise, then persists its identity to `.wildgecu/SOUL.md` in your current working directory.
+
+> **Tip:** The setup wizard also triggers automatically on `wildgecu start` if no config exists yet.
+
+### 3. Start chatting
+
+```bash
+wildgecu            # interactive chat (default command)
+wildgecu code       # coding agent scoped to the current directory
+```
+
+Switch models at runtime with `--model`:
+
+```bash
+wildgecu --model openai/gpt-4o
+wildgecu --model local              # uses the "local" alias → ollama/llama3
+```
+
+### Verify your setup
+
+After completing the steps above, your file tree should look like this:
+
+```
+~/.wildgecu/                    # global home
+├── .env                        # API keys (created by setup wizard)
+└── wildgecu.yaml               # config (created by setup wizard)
+
+./.wildgecu/                    # project-local (in your working directory)
+└── SOUL.md                     # agent identity (created by init)
+```
+
+If something is wrong, WildGecu will tell you — missing API keys, unknown providers, or invalid model references all produce clear error messages at startup.
+
+### Manual configuration (advanced)
+
+If you prefer to skip the wizard and configure manually, create the files yourself before running any command.
+
+**`.env` file** — store provider API keys:
 
 ```bash
 cat > ~/.wildgecu/.env << 'EOF'
-# Required: at least one provider key
 GEMINI_API_KEY=your-gemini-api-key
-
-# Optional: add more providers as needed
 # OPENAI_API_KEY=your-openai-api-key
 # MISTRAL_API_KEY=your-mistral-api-key
 # REGOLO_API_KEY=your-regolo-api-key
-
-# Optional: Telegram bot bridge
 # TELEGRAM_BOT_TOKEN=your-bot-token
 EOF
 ```
 
 > **Tip:** Environment variables already set in your shell take priority over values in `.env`.
 
-### 4. Create the config file (`wildgecu.yaml`)
-
-If you skip this step, WildGecu auto-generates a default Gemini config on first run. To customize it upfront, create `~/.wildgecu/wildgecu.yaml`:
+**`wildgecu.yaml`** — provider and model configuration:
 
 #### Minimal setup (Gemini only)
 
@@ -191,45 +227,6 @@ default_model: gemini/gemini-2.5-flash
 ```
 
 The `env(VAR_NAME)` syntax resolves values from your `.env` file or shell environment. If a referenced variable is missing, WildGecu exits with an error naming the unset variable.
-
-### 5. Bootstrap your agent's identity
-
-Run the `init` command to create your agent's personality through an interactive interview:
-
-```bash
-wildgecu init
-```
-
-The agent will ask about its name, purpose, personality, and expertise. When the conversation ends, it persists the identity to `.wildgecu/SOUL.md` in your current working directory.
-
-### 6. Start chatting
-
-```bash
-wildgecu            # interactive chat (default command)
-wildgecu code       # coding agent scoped to the current directory
-```
-
-Switch models at runtime with `--model`:
-
-```bash
-wildgecu --model openai/gpt-4o
-wildgecu --model local              # uses the "local" alias → ollama/llama3
-```
-
-### Verify your setup
-
-After completing the steps above, your file tree should look like this:
-
-```
-~/.wildgecu/                    # global home
-├── .env                        # API keys (step 3)
-└── wildgecu.yaml               # config (step 4, or auto-generated)
-
-./.wildgecu/                    # project-local (in your working directory)
-└── SOUL.md                     # agent identity (step 5)
-```
-
-If something is wrong, WildGecu will tell you — missing API keys, unknown providers, or invalid model references all produce clear error messages at startup.
 
 ## CLI commands
 

--- a/x/setup/setup.go
+++ b/x/setup/setup.go
@@ -42,11 +42,11 @@ type provider struct {
 }
 
 var providers = []provider{
-	{Name: "Gemini", Type: "gemini", APIKeyEnv: "GEMINI_API_KEY", Supported: true, Models: []string{"gemini-2.5-flash", "gemini-2.5-pro", "gemini-2.0-flash"}},                    //nolint:gosec // env var name, not a credential
-	{Name: "OpenAI", Type: "openai", APIKeyEnv: "OPENAI_API_KEY", Supported: true, Models: []string{"gpt-4o", "gpt-4o-mini", "o3-mini"}},                                         //nolint:gosec // env var name, not a credential
-	{Name: "Ollama", Type: "ollama", BaseURL: config.KnownBaseURLs["ollama"], Supported: true, Models: []string{"llama3.3", "qwen3", "gemma3", "phi4", "deepseek-r1"}},
-	{Name: "Mistral", Type: "mistral", APIKeyEnv: "MISTRAL_API_KEY", BaseURL: config.KnownBaseURLs["mistral"], Supported: true, Models: []string{"mistral-large-latest", "mistral-small-latest"}},   //nolint:gosec // env var name, not a credential
-	{Name: "Regolo", Type: "regolo", APIKeyEnv: "REGOLO_API_KEY", BaseURL: config.KnownBaseURLs["regolo"], Supported: true, Models: []string{"deepseek-r1", "llama-4-maverick"}},                   //nolint:gosec // env var name, not a credential
+	{Name: "Gemini", Type: "gemini", APIKeyEnv: "GEMINI_API_KEY", Supported: true, Models: []string{"gemini-3.1-flash-preview", "gemini-3.1-flash-lite-preview"}},                                                    //nolint:gosec // env var name, not a credential
+	{Name: "OpenAI", Type: "openai", APIKeyEnv: "OPENAI_API_KEY", Supported: true, Models: []string{"gpt-5.4", "o3", "o4-mini", "gpt-5.4-mini"}},                                                                    //nolint:gosec // env var name, not a credential
+	{Name: "Ollama", Type: "ollama", BaseURL: config.KnownBaseURLs["ollama"], Supported: true, Models: []string{"qwen3-coder-next", "devstral-small-2", "qwen3-coder", "gemma4", "llama4"}},
+	{Name: "Mistral", Type: "mistral", APIKeyEnv: "MISTRAL_API_KEY", BaseURL: config.KnownBaseURLs["mistral"], Supported: true, Models: []string{"mistral-small-latest", "devstral-2512", "mistral-large-latest"}},   //nolint:gosec // env var name, not a credential
+	{Name: "Regolo", Type: "regolo", APIKeyEnv: "REGOLO_API_KEY", BaseURL: config.KnownBaseURLs["regolo"], Supported: true, Models: []string{"Qwen3.5-122B", "Mistral-Small-4-119B", "Qwen3-Coder-Next"}},           //nolint:gosec // env var name, not a credential
 }
 
 // Result holds the outcome of a setup run for display purposes.

--- a/x/setup/setup_test.go
+++ b/x/setup/setup_test.go
@@ -30,8 +30,8 @@ func TestRun(t *testing.T) {
 		if result.BaseURL != "http://localhost:11434/v1" {
 			t.Errorf("BaseURL = %q, want %q", result.BaseURL, "http://localhost:11434/v1")
 		}
-		if result.Model != "llama3.3" {
-			t.Errorf("Model = %q, want %q", result.Model, "llama3.3")
+		if result.Model != "qwen3-coder-next" {
+			t.Errorf("Model = %q, want %q", result.Model, "qwen3-coder-next")
 		}
 		if result.EnvFilePath != "" {
 			t.Errorf("EnvFilePath = %q, want empty (Ollama has no API key)", result.EnvFilePath)
@@ -42,8 +42,8 @@ func TestRun(t *testing.T) {
 		if cfg.DefaultModel != "base" {
 			t.Errorf("DefaultModel = %q, want %q", cfg.DefaultModel, "base")
 		}
-		if cfg.Models["base"] != "ollama/llama3.3" {
-			t.Errorf("Models[base] = %q, want %q", cfg.Models["base"], "ollama/llama3.3")
+		if cfg.Models["base"] != "ollama/qwen3-coder-next" {
+			t.Errorf("Models[base] = %q, want %q", cfg.Models["base"], "ollama/qwen3-coder-next")
 		}
 
 		p, ok := cfg.Providers["ollama"]
@@ -81,7 +81,7 @@ func TestRun(t *testing.T) {
 
 	t.Run("OllamaWithModelByNumber", func(t *testing.T) {
 		homeDir := t.TempDir()
-		// Select Ollama (3), accept default base URL, pick model #3 (gemma3).
+		// Select Ollama (3), accept default base URL, pick model #3 (qwen3-coder).
 		stdin := strings.NewReader("3\n\n3\n")
 		var stdout bytes.Buffer
 
@@ -90,13 +90,13 @@ func TestRun(t *testing.T) {
 			t.Fatalf("Run() error = %v", err)
 		}
 
-		if result.Model != "gemma3" {
-			t.Errorf("Model = %q, want %q", result.Model, "gemma3")
+		if result.Model != "qwen3-coder" {
+			t.Errorf("Model = %q, want %q", result.Model, "qwen3-coder")
 		}
 
 		cfg := loadTestConfig(t, homeDir)
-		if cfg.Models["base"] != "ollama/gemma3" {
-			t.Errorf("Models[base] = %q, want %q", cfg.Models["base"], "ollama/gemma3")
+		if cfg.Models["base"] != "ollama/qwen3-coder" {
+			t.Errorf("Models[base] = %q, want %q", cfg.Models["base"], "ollama/qwen3-coder")
 		}
 	})
 
@@ -131,9 +131,9 @@ func TestRun(t *testing.T) {
 		baseURL      string // expected default; empty means no base URL prompt
 		model        string // expected default model
 	}{
-		{"OpenAI", "2", "openai", "oai-key-123", "OPENAI_API_KEY", "", "gpt-4o"},
-		{"Mistral", "4", "mistral", "mistral-key-123", "MISTRAL_API_KEY", "https://api.mistral.ai/v1", "mistral-large-latest"},
-		{"Regolo", "5", "regolo", "regolo-key-123", "REGOLO_API_KEY", "https://api.regolo.ai/v1", "deepseek-r1"},
+		{"OpenAI", "2", "openai", "oai-key-123", "OPENAI_API_KEY", "", "gpt-5.4"},
+		{"Mistral", "4", "mistral", "mistral-key-123", "MISTRAL_API_KEY", "https://api.mistral.ai/v1", "mistral-small-latest"},
+		{"Regolo", "5", "regolo", "regolo-key-123", "REGOLO_API_KEY", "https://api.regolo.ai/v1", "Qwen3.5-122B"},
 	}
 
 	for _, tc := range apiKeyProviders {
@@ -334,8 +334,8 @@ func TestRun(t *testing.T) {
 		if result.ProviderType != "gemini" {
 			t.Errorf("ProviderType = %q, want %q", result.ProviderType, "gemini")
 		}
-		if result.Model != "gemini-2.5-flash" {
-			t.Errorf("Model = %q, want %q", result.Model, "gemini-2.5-flash")
+		if result.Model != "gemini-3.1-flash-preview" {
+			t.Errorf("Model = %q, want %q", result.Model, "gemini-3.1-flash-preview")
 		}
 		if result.EnvFilePath == "" {
 			t.Error("EnvFilePath should not be empty for Gemini")
@@ -368,8 +368,8 @@ func TestRun(t *testing.T) {
 		if cfg.DefaultModel != "base" {
 			t.Errorf("DefaultModel = %q, want %q", cfg.DefaultModel, "base")
 		}
-		if cfg.Models["base"] != "gemini/gemini-2.5-flash" {
-			t.Errorf("Models[base] = %q, want %q", cfg.Models["base"], "gemini/gemini-2.5-flash")
+		if cfg.Models["base"] != "gemini/gemini-3.1-flash-preview" {
+			t.Errorf("Models[base] = %q, want %q", cfg.Models["base"], "gemini/gemini-3.1-flash-preview")
 		}
 
 		p, ok := cfg.Providers["gemini"]
@@ -462,8 +462,8 @@ func TestRun(t *testing.T) {
 			t.Errorf("GEMINI_API_KEY = %q, want %q", envMap["GEMINI_API_KEY"], "good-key")
 		}
 
-		if result.Model != "gemini-2.5-flash" {
-			t.Errorf("Model = %q, want %q", result.Model, "gemini-2.5-flash")
+		if result.Model != "gemini-3.1-flash-preview" {
+			t.Errorf("Model = %q, want %q", result.Model, "gemini-3.1-flash-preview")
 		}
 	})
 
@@ -514,13 +514,13 @@ func TestFormatSummary(t *testing.T) {
 			ProviderName: "Ollama",
 			ProviderType: "ollama",
 			BaseURL:      "http://localhost:11434/v1",
-			Model:        "llama3.3",
+			Model:        "qwen3-coder-next",
 			ConfigPath:   "/home/user/.wildgecu/wildgecu.yaml",
 		}
 
 		summary := FormatSummary(r)
 
-		for _, want := range []string{"Ollama", "http://localhost:11434/v1", "llama3.3", "ollama/llama3.3", "/home/user/.wildgecu/wildgecu.yaml"} {
+		for _, want := range []string{"Ollama", "http://localhost:11434/v1", "qwen3-coder-next", "ollama/qwen3-coder-next", "/home/user/.wildgecu/wildgecu.yaml"} {
 			if !strings.Contains(summary, want) {
 				t.Errorf("summary missing %q:\n%s", want, summary)
 			}
@@ -531,7 +531,7 @@ func TestFormatSummary(t *testing.T) {
 		r := &Result{
 			ProviderName: "Gemini",
 			ProviderType: "gemini",
-			Model:        "gemini-2.5-flash",
+			Model:        "gemini-3.1-flash-preview",
 			ConfigPath:   "/tmp/wildgecu.yaml",
 		}
 
@@ -545,7 +545,7 @@ func TestFormatSummary(t *testing.T) {
 		r := &Result{
 			ProviderName: "Gemini",
 			ProviderType: "gemini",
-			Model:        "gemini-2.5-flash",
+			Model:        "gemini-3.1-flash-preview",
 			ConfigPath:   "/home/user/.wildgecu/wildgecu.yaml",
 			EnvFilePath:  "/home/user/.wildgecu/.env",
 		}


### PR DESCRIPTION
## Summary
- Update default model lists for all providers (Gemini, OpenAI, Ollama, Mistral, Regolo) to latest available models
- Replace the manual 6-step getting started flow in README with the new interactive setup wizard
- Add Mistral and Regolo to the prerequisites provider list
- Move manual `.env` and `wildgecu.yaml` configuration into an "advanced" section

## Test plan
- [ ] Run `go test ./x/setup/...` to verify updated model lists
- [ ] Verify README renders correctly on GitHub