### PR TITLE
feat: suspend/resume and manual test runs for cron jobs with timeout

### DIFF
--- a/cmd/cron.go
+++ b/cmd/cron.go
@@ -97,12 +97,14 @@ func renderJobList(out io.Writer, jobs []cron.JobInfo) error {
 	}
 
 	w := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(w, "NAME\tSCHEDULE\tSTATUS\tLAST RUN\tNEXT RUN\tPROMPT")
-	for _, j := range jobs {
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n",
+	fmt.Fprintln(w, "NAME\tSCHEDULE\tSTATUS\tTIMEOUT\tLAST RUN\tNEXT RUN\tPROMPT")
+	for i := range jobs {
+		j := &jobs[i]
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
 			j.Name,
 			dashIfEmpty(j.Schedule),
 			statusCell(j),
+			dashIfEmpty(j.Timeout),
 			formatTimeCell(j.LastRun),
 			formatTimeCell(j.NextRun),
 			truncPrompt(j.Prompt),
@@ -126,18 +128,22 @@ func renderFilesystemFallback(stdout, stderr io.Writer, dir string) error {
 	}
 
 	w := tabwriter.NewWriter(stdout, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(w, "NAME\tSCHEDULE\tSTATUS\tPROMPT")
+	fmt.Fprintln(w, "NAME\tSCHEDULE\tSTATUS\tTIMEOUT\tPROMPT")
 	for _, r := range results {
 		if r.Err != nil {
-			fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", r.Name, "-", "(daemon offline)", "")
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", r.Name, "-", "(daemon offline)", "-", "")
 			continue
 		}
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", r.Job.Name, r.Job.Schedule, "(daemon offline)", truncPrompt(r.Job.Prompt))
+		timeout := ""
+		if r.Job.Timeout > 0 {
+			timeout = r.Job.Timeout.String()
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", r.Job.Name, r.Job.Schedule, "(daemon offline)", dashIfEmpty(timeout), truncPrompt(r.Job.Prompt))
 	}
 	return w.Flush()
 }
 
-func statusCell(j cron.JobInfo) string {
+func statusCell(j *cron.JobInfo) string {
 	if j.Status == cron.StatusError && j.Error != "" {
 		return fmt.Sprintf("error: %s", j.Error)
 	}

--- a/cmd/cron.go
+++ b/cmd/cron.go
@@ -1,11 +1,14 @@
 package cmd
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"text/tabwriter"
+	"time"
 
 	"github.com/ludusrusso/wildgecu/pkg/cron"
 	"github.com/ludusrusso/wildgecu/pkg/daemon"
@@ -46,30 +49,126 @@ func cronLsCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-
-			jobs, errs := cron.LoadAll(dir)
-			for _, e := range errs {
-				fmt.Fprintf(os.Stderr, "warning: %v\n", e)
-			}
-
-			if len(jobs) == 0 {
-				fmt.Println("No cron jobs found.")
-				fmt.Println("Use 'wildgecu cron add' to create one.")
-				return nil
-			}
-
-			w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-			fmt.Fprintln(w, "NAME\tSCHEDULE\tPROMPT")
-			for _, j := range jobs {
-				prompt := j.Prompt
-				if len(prompt) > 60 {
-					prompt = prompt[:57] + "..."
-				}
-				fmt.Fprintf(w, "%s\t%s\t%s\n", j.Name, j.Schedule, prompt)
-			}
-			return w.Flush()
+			return runCronLs(cmd.OutOrStdout(), cmd.ErrOrStderr(), dir, daemon.IsRunning(), daemon.SendCommand)
 		},
 	}
+}
+
+// sendCmdFunc matches daemon.SendCommand so tests can stub the daemon round-trip.
+type sendCmdFunc func(cmd string, args map[string]any) (*daemon.Response, error)
+
+func runCronLs(stdout, stderr io.Writer, dir string, daemonUp bool, send sendCmdFunc) error {
+	if daemonUp {
+		resp, err := send("cron-list", nil)
+		switch {
+		case err != nil:
+			fmt.Fprintf(stderr, "warning: daemon query failed: %v\n", err)
+		case !resp.OK:
+			fmt.Fprintf(stderr, "warning: daemon query failed: %s\n", resp.Error)
+		default:
+			jobs, decodeErr := decodeJobInfos(resp.Payload)
+			if decodeErr != nil {
+				fmt.Fprintf(stderr, "warning: daemon response: %v\n", decodeErr)
+			} else {
+				return renderJobList(stdout, jobs)
+			}
+		}
+	}
+	return renderFilesystemFallback(stdout, stderr, dir)
+}
+
+func decodeJobInfos(payload any) ([]cron.JobInfo, error) {
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+	var jobs []cron.JobInfo
+	if err := json.Unmarshal(raw, &jobs); err != nil {
+		return nil, err
+	}
+	return jobs, nil
+}
+
+func renderJobList(out io.Writer, jobs []cron.JobInfo) error {
+	if len(jobs) == 0 {
+		fmt.Fprintln(out, "No cron jobs found.")
+		fmt.Fprintln(out, "Use 'wildgecu cron add' to create one.")
+		return nil
+	}
+
+	w := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "NAME\tSCHEDULE\tSTATUS\tLAST RUN\tNEXT RUN\tPROMPT")
+	for _, j := range jobs {
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n",
+			j.Name,
+			dashIfEmpty(j.Schedule),
+			statusCell(j),
+			formatTimeCell(j.LastRun),
+			formatTimeCell(j.NextRun),
+			truncPrompt(j.Prompt),
+		)
+	}
+	return w.Flush()
+}
+
+func renderFilesystemFallback(stdout, stderr io.Writer, dir string) error {
+	results := cron.LoadAllResults(dir)
+	for _, r := range results {
+		if r.Err != nil {
+			fmt.Fprintf(stderr, "warning: %v\n", r.Err)
+		}
+	}
+
+	if len(results) == 0 {
+		fmt.Fprintln(stdout, "No cron jobs found.")
+		fmt.Fprintln(stdout, "Use 'wildgecu cron add' to create one.")
+		return nil
+	}
+
+	w := tabwriter.NewWriter(stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "NAME\tSCHEDULE\tSTATUS\tPROMPT")
+	for _, r := range results {
+		if r.Err != nil {
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", r.Name, "-", "(daemon offline)", "")
+			continue
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", r.Job.Name, r.Job.Schedule, "(daemon offline)", truncPrompt(r.Job.Prompt))
+	}
+	return w.Flush()
+}
+
+func statusCell(j cron.JobInfo) string {
+	if j.Status == cron.StatusError && j.Error != "" {
+		return fmt.Sprintf("error: %s", j.Error)
+	}
+	if j.Status == "" {
+		return "-"
+	}
+	return string(j.Status)
+}
+
+func formatTimeCell(s string) string {
+	if s == "" {
+		return "-"
+	}
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return t.Local().Format("2006-01-02 15:04")
+	}
+	return s
+}
+
+func dashIfEmpty(s string) string {
+	if s == "" {
+		return "-"
+	}
+	return s
+}
+
+func truncPrompt(p string) string {
+	if len(p) > 60 {
+		return p[:57] + "..."
+	}
+	return p
 }
 
 func cronReloadCmd() *cobra.Command {

--- a/cmd/cron.go
+++ b/cmd/cron.go
@@ -17,6 +17,7 @@ func init() {
 	cmd := cronCmd()
 	cmd.AddCommand(cronLsCmd())
 	cmd.AddCommand(cronRmCmd())
+	cmd.AddCommand(cronReloadCmd())
 	rootCmd.AddCommand(cmd)
 }
 
@@ -67,6 +68,28 @@ func cronLsCmd() *cobra.Command {
 				fmt.Fprintf(w, "%s\t%s\t%s\n", j.Name, j.Schedule, prompt)
 			}
 			return w.Flush()
+		},
+	}
+}
+
+func cronReloadCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "reload",
+		Short: "Ask the daemon to reload cron jobs from disk",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if !daemon.IsRunning() {
+				return fmt.Errorf("daemon is not running")
+			}
+			resp, err := daemon.SendCommand("cron-reload", nil)
+			if err != nil {
+				return fmt.Errorf("reload: %w", err)
+			}
+			if !resp.OK {
+				return fmt.Errorf("reload: %s", resp.Error)
+			}
+			fmt.Println("Cron jobs reloaded.")
+			return nil
 		},
 	}
 }

--- a/cmd/cron_run.go
+++ b/cmd/cron_run.go
@@ -1,0 +1,108 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/signal"
+
+	"github.com/ludusrusso/wildgecu/pkg/daemon"
+
+	"github.com/spf13/cobra"
+)
+
+// Reserved exit codes for `wildgecu cron test`. Values < 125 are reserved
+// for the job's own exit code so scripts can distinguish CLI-level failures
+// from job failures.
+const (
+	exitDaemonUnreachable = 125
+	exitNoJobFound        = 126
+	exitDetached          = 130
+)
+
+func init() {
+	for _, c := range rootCmd.Commands() {
+		if c.Use == "cron" {
+			c.AddCommand(cronTestCmd())
+			return
+		}
+	}
+}
+
+func cronTestCmd() *cobra.Command {
+	var timeoutFlag string
+	cmd := &cobra.Command{
+		Use:   "test <name>",
+		Short: "Run a cron job now and stream its output",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(c *cobra.Command, args []string) error {
+			c.SilenceUsage = true
+			code := runCronTest(c.OutOrStdout(), c.ErrOrStderr(), args[0], timeoutFlag, daemon.DialSocket)
+			if code != 0 {
+				os.Exit(code)
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&timeoutFlag, "timeout", "", "override timeout (Go duration, e.g. 30s, 5m)")
+	return cmd
+}
+
+// dialFn opens a connection to the daemon socket. Abstracted for testing.
+type dialFn func() (net.Conn, error)
+
+func runCronTest(stdout, stderr io.Writer, name, timeout string, dial dialFn) int {
+	conn, err := dial()
+	if err != nil {
+		fmt.Fprintf(stderr, "daemon unreachable: %v\n", err)
+		return exitDaemonUnreachable
+	}
+	defer conn.Close()
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt)
+	defer signal.Stop(sigCh)
+
+	done := make(chan int, 1)
+	go func() {
+		done <- streamCronTest(stdout, stderr, conn, name, timeout)
+	}()
+
+	select {
+	case code := <-done:
+		return code
+	case <-sigCh:
+		fmt.Fprintln(stderr, "detached; job still running")
+		return exitDetached
+	}
+}
+
+func streamCronTest(stdout, stderr io.Writer, conn net.Conn, name, timeout string) int {
+	req := daemon.CronTestRequest{Type: "cron.test", Name: name, Timeout: timeout}
+	if err := json.NewEncoder(conn).Encode(req); err != nil {
+		fmt.Fprintf(stderr, "send request: %v\n", err)
+		return exitDaemonUnreachable
+	}
+
+	dec := json.NewDecoder(conn)
+	for {
+		var ev daemon.CronTestEvent
+		if err := dec.Decode(&ev); err != nil {
+			fmt.Fprintf(stderr, "read event: %v\n", err)
+			return exitDaemonUnreachable
+		}
+		switch ev.Type {
+		case "stdout":
+			fmt.Fprint(stdout, ev.Data)
+		case "stderr":
+			fmt.Fprint(stderr, ev.Data)
+		case "done":
+			if ev.Error != "" {
+				fmt.Fprintln(stderr, ev.Error)
+			}
+			return ev.ExitCode
+		}
+	}
+}

--- a/cmd/cron_run_test.go
+++ b/cmd/cron_run_test.go
@@ -1,0 +1,141 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"net"
+	"strings"
+	"testing"
+
+	"github.com/ludusrusso/wildgecu/pkg/daemon"
+)
+
+// fakeDaemon simulates the daemon side of a cron-test streaming connection.
+// It reads the CLI's request, emits the configured sequence of events, then
+// closes the server-side connection.
+func fakeDaemon(t *testing.T, events []daemon.CronTestEvent) dialFn {
+	t.Helper()
+	return func() (net.Conn, error) {
+		client, server := net.Pipe()
+		go func() {
+			defer server.Close()
+			var req daemon.CronTestRequest
+			if err := json.NewDecoder(server).Decode(&req); err != nil {
+				return
+			}
+			enc := json.NewEncoder(server)
+			for _, ev := range events {
+				if err := enc.Encode(ev); err != nil {
+					return
+				}
+			}
+		}()
+		return client, nil
+	}
+}
+
+func TestRunCronTest(t *testing.T) {
+	t.Run("streams stdout and exits with job code", func(t *testing.T) {
+		dial := fakeDaemon(t, []daemon.CronTestEvent{
+			{Type: "stdout", Data: "line one\n"},
+			{Type: "stdout", Data: "line two\n"},
+			{Type: "done", ExitCode: 0, Duration: "1s"},
+		})
+
+		var stdout, stderr bytes.Buffer
+		code := runCronTest(&stdout, &stderr, "foo", "", dial)
+
+		if code != 0 {
+			t.Errorf("expected 0, got %d", code)
+		}
+		if stdout.String() != "line one\nline two\n" {
+			t.Errorf("stdout = %q", stdout.String())
+		}
+	})
+
+	t.Run("non-zero job exit is propagated", func(t *testing.T) {
+		dial := fakeDaemon(t, []daemon.CronTestEvent{
+			{Type: "stderr", Data: "boom\n"},
+			{Type: "done", ExitCode: 1},
+		})
+
+		var stdout, stderr bytes.Buffer
+		code := runCronTest(&stdout, &stderr, "foo", "", dial)
+		if code != 1 {
+			t.Errorf("expected 1, got %d", code)
+		}
+		if !strings.Contains(stderr.String(), "boom") {
+			t.Errorf("expected boom in stderr, got %q", stderr.String())
+		}
+	})
+
+	t.Run("daemon unreachable returns 125", func(t *testing.T) {
+		dial := func() (net.Conn, error) { return nil, errors.New("no socket") }
+		var stdout, stderr bytes.Buffer
+		code := runCronTest(&stdout, &stderr, "foo", "", dial)
+		if code != exitDaemonUnreachable {
+			t.Errorf("expected 125, got %d", code)
+		}
+		if !strings.Contains(stderr.String(), "daemon unreachable") {
+			t.Errorf("expected 'daemon unreachable' in stderr, got %q", stderr.String())
+		}
+	})
+
+	t.Run("unknown job returns 126 via done event", func(t *testing.T) {
+		dial := fakeDaemon(t, []daemon.CronTestEvent{
+			{Type: "done", ExitCode: 126, Error: "no job named \"ghost\""},
+		})
+		var stdout, stderr bytes.Buffer
+		code := runCronTest(&stdout, &stderr, "ghost", "", dial)
+		if code != 126 {
+			t.Errorf("expected 126, got %d", code)
+		}
+		if !strings.Contains(stderr.String(), "no job named") {
+			t.Errorf("expected error in stderr, got %q", stderr.String())
+		}
+	})
+
+	t.Run("timeout flag is sent in request", func(t *testing.T) {
+		var got daemon.CronTestRequest
+		dial := func() (net.Conn, error) {
+			client, server := net.Pipe()
+			go func() {
+				defer server.Close()
+				_ = json.NewDecoder(server).Decode(&got)
+				_ = json.NewEncoder(server).Encode(daemon.CronTestEvent{Type: "done"})
+			}()
+			return client, nil
+		}
+
+		var stdout, stderr bytes.Buffer
+		runCronTest(&stdout, &stderr, "foo", "45s", dial)
+
+		if got.Timeout != "45s" {
+			t.Errorf("expected timeout=45s in request, got %q", got.Timeout)
+		}
+		if got.Type != "cron.test" {
+			t.Errorf("expected type=cron.test, got %q", got.Type)
+		}
+		if got.Name != "foo" {
+			t.Errorf("expected name=foo, got %q", got.Name)
+		}
+	})
+
+	t.Run("unexpected EOF before done returns 125", func(t *testing.T) {
+		dial := func() (net.Conn, error) {
+			client, server := net.Pipe()
+			go func() {
+				var req daemon.CronTestRequest
+				_ = json.NewDecoder(server).Decode(&req)
+				server.Close()
+			}()
+			return client, nil
+		}
+		var stdout, stderr bytes.Buffer
+		code := runCronTest(&stdout, &stderr, "foo", "", dial)
+		if code != exitDaemonUnreachable {
+			t.Errorf("expected 125 on EOF, got %d", code)
+		}
+	})
+}

--- a/cmd/cron_suspend.go
+++ b/cmd/cron_suspend.go
@@ -1,0 +1,69 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/ludusrusso/wildgecu/pkg/daemon"
+
+	"github.com/spf13/cobra"
+)
+
+// exitCodeNoJob is returned when the target cron job does not exist or has
+// config errors that prevent it from being loaded.
+const exitCodeNoJob = 126
+
+func init() {
+	for _, c := range rootCmd.Commands() {
+		if c.Use == "cron" {
+			c.AddCommand(cronSuspendCmd())
+			c.AddCommand(cronResumeCmd())
+			return
+		}
+	}
+}
+
+func cronSuspendCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "suspend <name>",
+		Short: "Suspend a cron job (pause without deleting its config)",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runCronToggle(cmd, "cron-suspend", args[0])
+		},
+	}
+}
+
+func cronResumeCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "resume <name>",
+		Short: "Resume a suspended cron job",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runCronToggle(cmd, "cron-resume", args[0])
+		},
+	}
+}
+
+func runCronToggle(cmd *cobra.Command, rpc, name string) error {
+	if !daemon.IsRunning() {
+		return fmt.Errorf("daemon is not running")
+	}
+	resp, err := daemon.SendCommand(rpc, map[string]any{"name": name})
+	if err != nil {
+		return err
+	}
+	if !resp.OK {
+		cmd.SilenceUsage = true
+		if strings.Contains(resp.Error, "no job named") || strings.Contains(resp.Error, "config errors") {
+			fmt.Fprintln(os.Stderr, resp.Error)
+			os.Exit(exitCodeNoJob)
+		}
+		return fmt.Errorf("%s", resp.Error)
+	}
+	if msg, ok := resp.Payload.(string); ok && msg != "" {
+		fmt.Println(msg)
+	}
+	return nil
+}

--- a/cmd/cron_test.go
+++ b/cmd/cron_test.go
@@ -1,0 +1,127 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ludusrusso/wildgecu/pkg/cron"
+	"github.com/ludusrusso/wildgecu/pkg/daemon"
+)
+
+func TestRunCronLs(t *testing.T) {
+	t.Run("daemon up renders STATUS/LAST RUN/NEXT RUN with mixed states", func(t *testing.T) {
+		payload := []cron.JobInfo{
+			{
+				Name:     "active",
+				Schedule: "0 9 * * *",
+				Status:   cron.StatusRunning,
+				Prompt:   "say hello",
+				NextRun:  "2026-04-20T09:00:00Z",
+				LastRun:  "2026-04-19T09:00:00Z",
+			},
+			{
+				Name:     "paused",
+				Schedule: "0 9 * * *",
+				Status:   cron.StatusSuspended,
+				Prompt:   "say goodbye",
+			},
+			{
+				Name:   "broken",
+				Status: cron.StatusError,
+				Error:  "missing schedule",
+			},
+		}
+
+		stub := func(cmd string, args map[string]any) (*daemon.Response, error) {
+			if cmd != "cron-list" {
+				t.Fatalf("unexpected command %q", cmd)
+			}
+			raw, _ := json.Marshal(payload)
+			var generic any
+			_ = json.Unmarshal(raw, &generic)
+			return &daemon.Response{OK: true, Payload: generic}, nil
+		}
+
+		var stdout, stderr bytes.Buffer
+		if err := runCronLs(&stdout, &stderr, t.TempDir(), true, stub); err != nil {
+			t.Fatalf("runCronLs: %v", err)
+		}
+
+		out := stdout.String()
+		for _, want := range []string{"NAME", "SCHEDULE", "STATUS", "LAST RUN", "NEXT RUN", "PROMPT",
+			"active", "running", "paused", "suspended", "broken", "error: missing schedule"} {
+			if !strings.Contains(out, want) {
+				t.Errorf("output missing %q:\n%s", want, out)
+			}
+		}
+	})
+
+	t.Run("daemon down falls back to filesystem listing", func(t *testing.T) {
+		dir := t.TempDir()
+		os.WriteFile(filepath.Join(dir, "good.md"), []byte("---\nname: good\ncron: \"0 9 * * *\"\n---\nprompt"), 0o644)
+		os.WriteFile(filepath.Join(dir, "bad.md"), []byte("---\nname: bad\n---\nmissing schedule"), 0o644)
+
+		stub := func(cmd string, args map[string]any) (*daemon.Response, error) {
+			t.Fatal("should not call daemon in fallback mode")
+			return nil, nil
+		}
+
+		var stdout, stderr bytes.Buffer
+		if err := runCronLs(&stdout, &stderr, dir, false, stub); err != nil {
+			t.Fatalf("runCronLs: %v", err)
+		}
+
+		out := stdout.String()
+		if !strings.Contains(out, "(daemon offline)") {
+			t.Errorf("expected '(daemon offline)' status, got:\n%s", out)
+		}
+		if strings.Contains(out, "LAST RUN") || strings.Contains(out, "NEXT RUN") {
+			t.Errorf("fallback should omit LAST RUN/NEXT RUN:\n%s", out)
+		}
+		if !strings.Contains(out, "good") {
+			t.Errorf("expected 'good' job in output:\n%s", out)
+		}
+		if !strings.Contains(out, "bad") {
+			t.Errorf("expected 'bad' job (unparseable, by filename) in output:\n%s", out)
+		}
+	})
+
+	t.Run("daemon reachable but errors falls through to filesystem", func(t *testing.T) {
+		dir := t.TempDir()
+		os.WriteFile(filepath.Join(dir, "solo.md"), []byte("---\nname: solo\ncron: \"0 9 * * *\"\n---\nprompt"), 0o644)
+
+		stub := func(cmd string, args map[string]any) (*daemon.Response, error) {
+			return nil, errors.New("socket error")
+		}
+
+		var stdout, stderr bytes.Buffer
+		if err := runCronLs(&stdout, &stderr, dir, true, stub); err != nil {
+			t.Fatalf("runCronLs: %v", err)
+		}
+		if !strings.Contains(stderr.String(), "daemon query failed") {
+			t.Errorf("expected warning about daemon failure, got stderr:\n%s", stderr.String())
+		}
+		if !strings.Contains(stdout.String(), "(daemon offline)") {
+			t.Errorf("expected fallback rendering, got:\n%s", stdout.String())
+		}
+	})
+
+	t.Run("empty directory prints helpful message", func(t *testing.T) {
+		stub := func(cmd string, args map[string]any) (*daemon.Response, error) {
+			return &daemon.Response{OK: true, Payload: []any{}}, nil
+		}
+
+		var stdout, stderr bytes.Buffer
+		if err := runCronLs(&stdout, &stderr, t.TempDir(), true, stub); err != nil {
+			t.Fatalf("runCronLs: %v", err)
+		}
+		if !strings.Contains(stdout.String(), "No cron jobs found") {
+			t.Errorf("expected empty message, got:\n%s", stdout.String())
+		}
+	})
+}

--- a/cmd/cron_test.go
+++ b/cmd/cron_test.go
@@ -21,6 +21,7 @@ func TestRunCronLs(t *testing.T) {
 				Schedule: "0 9 * * *",
 				Status:   cron.StatusRunning,
 				Prompt:   "say hello",
+				Timeout:  "30m0s",
 				NextRun:  "2026-04-20T09:00:00Z",
 				LastRun:  "2026-04-19T09:00:00Z",
 			},
@@ -53,8 +54,8 @@ func TestRunCronLs(t *testing.T) {
 		}
 
 		out := stdout.String()
-		for _, want := range []string{"NAME", "SCHEDULE", "STATUS", "LAST RUN", "NEXT RUN", "PROMPT",
-			"active", "running", "paused", "suspended", "broken", "error: missing schedule"} {
+		for _, want := range []string{"NAME", "SCHEDULE", "STATUS", "TIMEOUT", "LAST RUN", "NEXT RUN", "PROMPT",
+			"active", "running", "30m0s", "paused", "suspended", "broken", "error: missing schedule"} {
 			if !strings.Contains(out, want) {
 				t.Errorf("output missing %q:\n%s", want, out)
 			}

--- a/pkg/cron/cron.go
+++ b/pkg/cron/cron.go
@@ -91,28 +91,54 @@ func Filename(name string) string {
 // LoadAll loads all cron jobs from a directory path.
 // It returns all successfully parsed jobs and any errors encountered.
 func LoadAll(dir string) ([]*CronJob, []error) {
-	matches, err := filepath.Glob(filepath.Join(dir, "*.md"))
-	if err != nil {
-		return nil, []error{fmt.Errorf("cron: search: %w", err)}
-	}
-
+	results := LoadAllResults(dir)
 	var jobs []*CronJob
 	var errs []error
+	for _, r := range results {
+		if r.Err != nil {
+			errs = append(errs, r.Err)
+			continue
+		}
+		jobs = append(jobs, r.Job)
+	}
+	return jobs, errs
+}
 
+// LoadResult is a per-file outcome from loading a cron directory. Successfully
+// parsed files populate Job; unparseable files populate Err. Name is derived
+// from the frontmatter when parseable, else from the filename stem.
+type LoadResult struct {
+	Name string
+	Path string
+	Job  *CronJob
+	Err  error
+}
+
+// LoadAllResults walks a cron directory and returns one LoadResult per .md
+// file, including unparseable ones. Unlike LoadAll it retains the filename
+// so callers can surface broken jobs by name.
+func LoadAllResults(dir string) []LoadResult {
+	matches, err := filepath.Glob(filepath.Join(dir, "*.md"))
+	if err != nil {
+		return []LoadResult{{Err: fmt.Errorf("cron: search: %w", err)}}
+	}
+
+	results := make([]LoadResult, 0, len(matches))
 	for _, path := range matches {
 		f := filepath.Base(path)
+		stem := strings.TrimSuffix(f, filepath.Ext(f))
 		data, err := os.ReadFile(path)
 		if err != nil {
-			errs = append(errs, fmt.Errorf("cron: read %s: %w", f, err))
+			results = append(results, LoadResult{Name: stem, Path: path, Err: fmt.Errorf("cron: read %s: %w", f, err)})
 			continue
 		}
 		job, err := Parse(data)
 		if err != nil {
-			errs = append(errs, fmt.Errorf("cron: %s: %w", f, err))
+			results = append(results, LoadResult{Name: stem, Path: path, Err: fmt.Errorf("cron: %s: %w", f, err)})
 			continue
 		}
-		jobs = append(jobs, job)
+		results = append(results, LoadResult{Name: job.Name, Path: path, Job: job})
 	}
 
-	return jobs, errs
+	return results
 }

--- a/pkg/cron/cron.go
+++ b/pkg/cron/cron.go
@@ -6,16 +6,18 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"go.yaml.in/yaml/v3"
 )
 
 // CronJob represents a scheduled LLM prompt.
 type CronJob struct {
-	Name      string `yaml:"name"`
-	Schedule  string `yaml:"cron"`
-	Suspended bool   `yaml:"suspended,omitempty"`
-	Prompt    string `yaml:"-"`
+	Name      string        `yaml:"name"`
+	Schedule  string        `yaml:"cron"`
+	Suspended bool          `yaml:"suspended,omitempty"`
+	Timeout   time.Duration `yaml:"-"`
+	Prompt    string        `yaml:"-"`
 }
 
 // Parse parses a cron job from a markdown file with YAML frontmatter.
@@ -43,19 +45,39 @@ func Parse(data []byte) (*CronJob, error) {
 	frontmatter := rest[:idx]
 	body := strings.TrimSpace(rest[idx+4:]) // skip "\n---"
 
-	var job CronJob
-	if err := yaml.Unmarshal([]byte(frontmatter), &job); err != nil {
+	var raw struct {
+		Name      string `yaml:"name"`
+		Schedule  string `yaml:"cron"`
+		Suspended bool   `yaml:"suspended,omitempty"`
+		Timeout   string `yaml:"timeout,omitempty"`
+	}
+	if err := yaml.Unmarshal([]byte(frontmatter), &raw); err != nil {
 		return nil, fmt.Errorf("cron: parse frontmatter: %w", err)
 	}
 
-	if job.Name == "" {
+	if raw.Name == "" {
 		return nil, fmt.Errorf("cron: name is required")
 	}
-	if job.Schedule == "" {
+	if raw.Schedule == "" {
 		return nil, fmt.Errorf("cron: cron schedule is required")
 	}
 
-	job.Prompt = body
+	job := CronJob{
+		Name:      raw.Name,
+		Schedule:  raw.Schedule,
+		Suspended: raw.Suspended,
+		Prompt:    body,
+	}
+	if raw.Timeout != "" {
+		d, err := time.ParseDuration(raw.Timeout)
+		if err != nil {
+			return nil, fmt.Errorf("cron: parse timeout %q: %w", raw.Timeout, err)
+		}
+		if d < 0 {
+			return nil, fmt.Errorf("cron: timeout must be non-negative, got %q", raw.Timeout)
+		}
+		job.Timeout = d
+	}
 	return &job, nil
 }
 
@@ -63,11 +85,16 @@ func Parse(data []byte) (*CronJob, error) {
 func Serialize(job *CronJob) ([]byte, error) {
 	var buf bytes.Buffer
 
+	timeout := ""
+	if job.Timeout > 0 {
+		timeout = job.Timeout.String()
+	}
 	fm, err := yaml.Marshal(struct {
 		Name      string `yaml:"name"`
 		Schedule  string `yaml:"cron"`
 		Suspended bool   `yaml:"suspended,omitempty"`
-	}{Name: job.Name, Schedule: job.Schedule, Suspended: job.Suspended})
+		Timeout   string `yaml:"timeout,omitempty"`
+	}{Name: job.Name, Schedule: job.Schedule, Suspended: job.Suspended, Timeout: timeout})
 	if err != nil {
 		return nil, fmt.Errorf("cron: marshal frontmatter: %w", err)
 	}

--- a/pkg/cron/cron.go
+++ b/pkg/cron/cron.go
@@ -12,9 +12,10 @@ import (
 
 // CronJob represents a scheduled LLM prompt.
 type CronJob struct {
-	Name     string `yaml:"name"`
-	Schedule string `yaml:"cron"`
-	Prompt   string `yaml:"-"`
+	Name      string `yaml:"name"`
+	Schedule  string `yaml:"cron"`
+	Suspended bool   `yaml:"suspended,omitempty"`
+	Prompt    string `yaml:"-"`
 }
 
 // Parse parses a cron job from a markdown file with YAML frontmatter.
@@ -63,9 +64,10 @@ func Serialize(job *CronJob) ([]byte, error) {
 	var buf bytes.Buffer
 
 	fm, err := yaml.Marshal(struct {
-		Name     string `yaml:"name"`
-		Schedule string `yaml:"cron"`
-	}{Name: job.Name, Schedule: job.Schedule})
+		Name      string `yaml:"name"`
+		Schedule  string `yaml:"cron"`
+		Suspended bool   `yaml:"suspended,omitempty"`
+	}{Name: job.Name, Schedule: job.Schedule, Suspended: job.Suspended})
 	if err != nil {
 		return nil, fmt.Errorf("cron: marshal frontmatter: %w", err)
 	}

--- a/pkg/cron/cron_test.go
+++ b/pkg/cron/cron_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestParseValid(t *testing.T) {
@@ -151,6 +152,94 @@ func TestSerializeSuspended(t *testing.T) {
 		}
 		if strings.Contains(string(data), "suspended") {
 			t.Errorf("expected serialized output to omit 'suspended' when false, got:\n%s", data)
+		}
+	})
+}
+
+func TestParseTimeout(t *testing.T) {
+	t.Run("parses Go duration strings", func(t *testing.T) {
+		cases := map[string]time.Duration{
+			"30m":    30 * time.Minute,
+			"2h":     2 * time.Hour,
+			"1h30m":  90 * time.Minute,
+			"500ms":  500 * time.Millisecond,
+		}
+		for in, want := range cases {
+			t.Run(in, func(t *testing.T) {
+				data := []byte("---\nname: foo\ncron: \"0 9 * * *\"\ntimeout: " + in + "\n---\nprompt")
+				job, err := Parse(data)
+				if err != nil {
+					t.Fatalf("Parse failed: %v", err)
+				}
+				if job.Timeout != want {
+					t.Errorf("expected Timeout=%s, got %s", want, job.Timeout)
+				}
+			})
+		}
+	})
+
+	t.Run("absent defaults to zero", func(t *testing.T) {
+		data := []byte("---\nname: foo\ncron: \"0 9 * * *\"\n---\nprompt")
+		job, err := Parse(data)
+		if err != nil {
+			t.Fatalf("Parse failed: %v", err)
+		}
+		if job.Timeout != 0 {
+			t.Errorf("expected Timeout=0 when absent, got %s", job.Timeout)
+		}
+	})
+
+	t.Run("invalid duration errors", func(t *testing.T) {
+		data := []byte("---\nname: foo\ncron: \"0 9 * * *\"\ntimeout: not-a-duration\n---\nprompt")
+		if _, err := Parse(data); err == nil {
+			t.Fatal("expected error for invalid timeout")
+		}
+	})
+
+	t.Run("negative duration errors", func(t *testing.T) {
+		data := []byte("---\nname: foo\ncron: \"0 9 * * *\"\ntimeout: -5m\n---\nprompt")
+		if _, err := Parse(data); err == nil {
+			t.Fatal("expected error for negative timeout")
+		}
+	})
+}
+
+func TestSerializeTimeout(t *testing.T) {
+	t.Run("non-zero round-trips", func(t *testing.T) {
+		original := &CronJob{
+			Name:     "foo",
+			Schedule: "0 9 * * *",
+			Timeout:  30 * time.Minute,
+			Prompt:   "hello",
+		}
+		data, err := Serialize(original)
+		if err != nil {
+			t.Fatalf("Serialize failed: %v", err)
+		}
+		if !strings.Contains(string(data), "timeout: 30m0s") {
+			t.Errorf("expected serialized output to contain 'timeout: 30m0s', got:\n%s", data)
+		}
+		parsed, err := Parse(data)
+		if err != nil {
+			t.Fatalf("Parse round-trip failed: %v", err)
+		}
+		if parsed.Timeout != 30*time.Minute {
+			t.Errorf("expected Timeout=30m after round-trip, got %s", parsed.Timeout)
+		}
+	})
+
+	t.Run("zero omits the field", func(t *testing.T) {
+		original := &CronJob{
+			Name:     "foo",
+			Schedule: "0 9 * * *",
+			Prompt:   "hello",
+		}
+		data, err := Serialize(original)
+		if err != nil {
+			t.Fatalf("Serialize failed: %v", err)
+		}
+		if strings.Contains(string(data), "timeout") {
+			t.Errorf("expected serialized output to omit 'timeout' when zero, got:\n%s", data)
 		}
 	})
 }

--- a/pkg/cron/cron_test.go
+++ b/pkg/cron/cron_test.go
@@ -80,6 +80,81 @@ func TestSerializeRoundTrip(t *testing.T) {
 	}
 }
 
+func TestParseSuspended(t *testing.T) {
+	t.Run("explicit true", func(t *testing.T) {
+		data := []byte("---\nname: foo\ncron: \"0 9 * * *\"\nsuspended: true\n---\nprompt")
+		job, err := Parse(data)
+		if err != nil {
+			t.Fatalf("Parse failed: %v", err)
+		}
+		if !job.Suspended {
+			t.Errorf("expected Suspended=true, got false")
+		}
+	})
+
+	t.Run("explicit false", func(t *testing.T) {
+		data := []byte("---\nname: foo\ncron: \"0 9 * * *\"\nsuspended: false\n---\nprompt")
+		job, err := Parse(data)
+		if err != nil {
+			t.Fatalf("Parse failed: %v", err)
+		}
+		if job.Suspended {
+			t.Errorf("expected Suspended=false, got true")
+		}
+	})
+
+	t.Run("absent defaults to false", func(t *testing.T) {
+		data := []byte("---\nname: foo\ncron: \"0 9 * * *\"\n---\nprompt")
+		job, err := Parse(data)
+		if err != nil {
+			t.Fatalf("Parse failed: %v", err)
+		}
+		if job.Suspended {
+			t.Errorf("expected Suspended=false when absent, got true")
+		}
+	})
+}
+
+func TestSerializeSuspended(t *testing.T) {
+	t.Run("true round-trip", func(t *testing.T) {
+		original := &CronJob{
+			Name:      "foo",
+			Schedule:  "0 9 * * *",
+			Suspended: true,
+			Prompt:    "hello",
+		}
+		data, err := Serialize(original)
+		if err != nil {
+			t.Fatalf("Serialize failed: %v", err)
+		}
+		if !strings.Contains(string(data), "suspended: true") {
+			t.Errorf("expected serialized output to contain 'suspended: true', got:\n%s", data)
+		}
+		parsed, err := Parse(data)
+		if err != nil {
+			t.Fatalf("Parse round-trip failed: %v", err)
+		}
+		if !parsed.Suspended {
+			t.Errorf("expected Suspended=true after round-trip")
+		}
+	})
+
+	t.Run("false omits the field", func(t *testing.T) {
+		original := &CronJob{
+			Name:     "foo",
+			Schedule: "0 9 * * *",
+			Prompt:   "hello",
+		}
+		data, err := Serialize(original)
+		if err != nil {
+			t.Fatalf("Serialize failed: %v", err)
+		}
+		if strings.Contains(string(data), "suspended") {
+			t.Errorf("expected serialized output to omit 'suspended' when false, got:\n%s", data)
+		}
+	})
+}
+
 func TestFilename(t *testing.T) {
 	if got := Filename("daily-summary"); got != "daily-summary.md" {
 		t.Errorf("expected daily-summary.md, got %q", got)

--- a/pkg/cron/executor.go
+++ b/pkg/cron/executor.go
@@ -2,6 +2,7 @@ package cron
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -21,7 +22,13 @@ type ExecutorConfig struct {
 // Execute runs a single cron job: calls the provider with the prompt
 // and writes the result to the results home.
 func Execute(ctx context.Context, cfg *ExecutorConfig, job *CronJob) {
-	cfg.Logger.Info("executing cron job", "name", job.Name)
+	cfg.Logger.Info("executing cron job", "name", job.Name, "timeout", job.Timeout)
+
+	if job.Timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, job.Timeout)
+		defer cancel()
+	}
 
 	resp, err := cfg.Provider.Generate(ctx, &provider.GenerateParams{
 		Messages: []provider.Message{
@@ -29,20 +36,30 @@ func Execute(ctx context.Context, cfg *ExecutorConfig, job *CronJob) {
 		},
 	})
 	if err != nil {
+		if job.Timeout > 0 && errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			cfg.Logger.Error("cron job timed out", "name", job.Name, "timeout", job.Timeout)
+			writeResult(cfg, job.Name, fmt.Sprintf("Timed out after %s.\n", job.Timeout))
+			return
+		}
 		cfg.Logger.Error("cron job failed", "name", job.Name, "error", err)
 		return
 	}
 
+	if filename := writeResult(cfg, job.Name, resp.Message.Content); filename != "" {
+		cfg.Logger.Info("cron job completed", "name", job.Name, "file", filename)
+	}
+}
+
+func writeResult(cfg *ExecutorConfig, name, content string) string {
 	ts := time.Now().UTC().Format("20060102-150405")
-	filename := fmt.Sprintf("%s-%s.md", job.Name, ts)
-
+	filename := fmt.Sprintf("%s-%s.md", name, ts)
 	if err := os.MkdirAll(cfg.Results, 0o755); err != nil {
-		cfg.Logger.Error("failed to create results dir", "name", job.Name, "error", err)
-		return
+		cfg.Logger.Error("failed to create results dir", "name", name, "error", err)
+		return ""
 	}
-	if err := os.WriteFile(filepath.Join(cfg.Results, filename), []byte(resp.Message.Content), 0o644); err != nil {
-		cfg.Logger.Error("failed to write cron result", "name", job.Name, "error", err)
+	if err := os.WriteFile(filepath.Join(cfg.Results, filename), []byte(content), 0o644); err != nil {
+		cfg.Logger.Error("failed to write cron result", "name", name, "error", err)
+		return ""
 	}
-
-	cfg.Logger.Info("cron job completed", "name", job.Name, "file", filename)
+	return filename
 }

--- a/pkg/cron/executor.go
+++ b/pkg/cron/executor.go
@@ -1,6 +1,7 @@
 package cron
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -12,6 +13,27 @@ import (
 	"github.com/ludusrusso/wildgecu/pkg/provider"
 )
 
+// Source identifies how a cron run was triggered. It is written into the
+// result file's frontmatter so manual invocations can be distinguished from
+// scheduled ticks.
+const (
+	SourceScheduled = "scheduled"
+	SourceManual    = "manual"
+)
+
+// Exit codes reported by ExecuteTest. Zero means the job succeeded; other
+// values let the CLI propagate a meaningful shell exit code.
+const (
+	exitSuccess = 0
+	exitError   = 1
+	exitTimeout = 124
+)
+
+// TestDefaultTimeout is applied to manual runs that have no configured
+// job timeout and no explicit override. Scheduled runs keep "no timeout"
+// as their default.
+const TestDefaultTimeout = 5 * time.Minute
+
 // ExecutorConfig holds the dependencies for executing a cron job.
 type ExecutorConfig struct {
 	Provider provider.Provider
@@ -19,14 +41,49 @@ type ExecutorConfig struct {
 	Logger   *slog.Logger
 }
 
-// Execute runs a single cron job: calls the provider with the prompt
-// and writes the result to the results home.
-func Execute(ctx context.Context, cfg *ExecutorConfig, job *CronJob) {
-	cfg.Logger.Info("executing cron job", "name", job.Name, "timeout", job.Timeout)
+// TestOptions configures a manual ExecuteTest run. All fields are optional.
+type TestOptions struct {
+	OnStdout func(string)
+	OnStderr func(string)
+	Timeout  time.Duration // override; 0 means fall back to job.Timeout then TestDefaultTimeout
+}
 
-	if job.Timeout > 0 {
+// TestResult reports the outcome of a manual run.
+type TestResult struct {
+	ExitCode int
+	Duration time.Duration
+}
+
+// Execute runs a scheduled cron job: calls the provider with the prompt
+// and writes the result to the results directory with source="scheduled".
+func Execute(ctx context.Context, cfg *ExecutorConfig, job *CronJob) {
+	runJob(ctx, cfg, job, SourceScheduled, job.Timeout, nil, nil)
+}
+
+// ExecuteTest runs a job manually (via `cron test`). It streams stdout/stderr
+// via the supplied callbacks, applies the timeout precedence
+// (opts.Timeout > job.Timeout > TestDefaultTimeout), and records the run in
+// the results directory with source="manual".
+func ExecuteTest(ctx context.Context, cfg *ExecutorConfig, job *CronJob, opts TestOptions) TestResult {
+	timeout := opts.Timeout
+	if timeout <= 0 {
+		timeout = job.Timeout
+	}
+	if timeout <= 0 {
+		timeout = TestDefaultTimeout
+	}
+	start := time.Now()
+	code := runJob(ctx, cfg, job, SourceManual, timeout, opts.OnStdout, opts.OnStderr)
+	return TestResult{ExitCode: code, Duration: time.Since(start)}
+}
+
+func runJob(ctx context.Context, cfg *ExecutorConfig, job *CronJob, source string, timeout time.Duration, onStdout, onStderr func(string)) int {
+	cfg.Logger.Info("executing cron job", "name", job.Name, "source", source, "timeout", timeout)
+
+	start := time.Now()
+	if timeout > 0 {
 		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, job.Timeout)
+		ctx, cancel = context.WithTimeout(ctx, timeout)
 		defer cancel()
 	}
 
@@ -35,30 +92,57 @@ func Execute(ctx context.Context, cfg *ExecutorConfig, job *CronJob) {
 			{Role: provider.RoleUser, Content: job.Prompt},
 		},
 	})
+	duration := time.Since(start)
+
 	if err != nil {
-		if job.Timeout > 0 && errors.Is(ctx.Err(), context.DeadlineExceeded) {
-			cfg.Logger.Error("cron job timed out", "name", job.Name, "timeout", job.Timeout)
-			writeResult(cfg, job.Name, fmt.Sprintf("Timed out after %s.\n", job.Timeout))
-			return
+		if timeout > 0 && errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			msg := fmt.Sprintf("Timed out after %s.\n", timeout)
+			cfg.Logger.Error("cron job timed out", "name", job.Name, "timeout", timeout)
+			if onStderr != nil {
+				onStderr(msg)
+			}
+			writeResult(cfg, job, source, "timeout", start, duration, msg)
+			return exitTimeout
 		}
 		cfg.Logger.Error("cron job failed", "name", job.Name, "error", err)
-		return
+		errMsg := fmt.Sprintf("error: %v\n", err)
+		if onStderr != nil {
+			onStderr(errMsg)
+		}
+		writeResult(cfg, job, source, "error", start, duration, errMsg)
+		return exitError
 	}
 
-	if filename := writeResult(cfg, job.Name, resp.Message.Content); filename != "" {
+	content := resp.Message.Content
+	if onStdout != nil {
+		onStdout(content)
+	}
+
+	if filename := writeResult(cfg, job, source, "success", start, duration, content); filename != "" {
 		cfg.Logger.Info("cron job completed", "name", job.Name, "file", filename)
 	}
+	return exitSuccess
 }
 
-func writeResult(cfg *ExecutorConfig, name, content string) string {
+func writeResult(cfg *ExecutorConfig, job *CronJob, source, status string, start time.Time, duration time.Duration, content string) string {
 	ts := time.Now().UTC().Format("20060102-150405")
-	filename := fmt.Sprintf("%s-%s.md", name, ts)
+	filename := fmt.Sprintf("%s-%s.md", job.Name, ts)
 	if err := os.MkdirAll(cfg.Results, 0o755); err != nil {
-		cfg.Logger.Error("failed to create results dir", "name", name, "error", err)
+		cfg.Logger.Error("failed to create results dir", "name", job.Name, "error", err)
 		return ""
 	}
-	if err := os.WriteFile(filepath.Join(cfg.Results, filename), []byte(content), 0o644); err != nil {
-		cfg.Logger.Error("failed to write cron result", "name", name, "error", err)
+
+	var buf bytes.Buffer
+	buf.WriteString("---\n")
+	fmt.Fprintf(&buf, "source: %s\n", source)
+	fmt.Fprintf(&buf, "started_at: %s\n", start.UTC().Format(time.RFC3339))
+	fmt.Fprintf(&buf, "duration: %s\n", duration)
+	fmt.Fprintf(&buf, "status: %s\n", status)
+	buf.WriteString("---\n")
+	buf.WriteString(content)
+
+	if err := os.WriteFile(filepath.Join(cfg.Results, filename), buf.Bytes(), 0o644); err != nil {
+		cfg.Logger.Error("failed to write cron result", "name", job.Name, "error", err)
 		return ""
 	}
 	return filename

--- a/pkg/cron/executor_test.go
+++ b/pkg/cron/executor_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/ludusrusso/wildgecu/pkg/provider"
 )
@@ -64,4 +65,88 @@ func TestExecute(t *testing.T) {
 	if !strings.HasSuffix(filename, ".md") {
 		t.Errorf("expected filename to end with .md, got %q", filename)
 	}
+}
+
+type blockingProvider struct{}
+
+func (p *blockingProvider) Generate(ctx context.Context, _ *provider.GenerateParams) (*provider.Response, error) {
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+type recordingProvider struct {
+	hadDeadline bool
+	response    string
+}
+
+func (p *recordingProvider) Generate(ctx context.Context, _ *provider.GenerateParams) (*provider.Response, error) {
+	_, p.hadDeadline = ctx.Deadline()
+	return &provider.Response{
+		Message: provider.Message{Role: provider.RoleModel, Content: p.response},
+	}, nil
+}
+
+func TestExecuteTimeout(t *testing.T) {
+	t.Run("cancels provider when deadline fires and records timeout", func(t *testing.T) {
+		resultsDir := t.TempDir()
+		cfg := &ExecutorConfig{
+			Provider: &blockingProvider{},
+			Results:  resultsDir,
+			Logger:   slog.Default(),
+		}
+		job := &CronJob{
+			Name:     "slow",
+			Schedule: "0 9 * * *",
+			Timeout:  20 * time.Millisecond,
+			Prompt:   "hang",
+		}
+
+		start := time.Now()
+		Execute(context.Background(), cfg, job)
+		elapsed := time.Since(start)
+
+		if elapsed > 2*time.Second {
+			t.Fatalf("Execute did not respect timeout; ran for %s", elapsed)
+		}
+
+		matches, err := filepath.Glob(filepath.Join(resultsDir, "slow-*.md"))
+		if err != nil {
+			t.Fatalf("Glob failed: %v", err)
+		}
+		if len(matches) != 1 {
+			t.Fatalf("expected 1 result file, got %d", len(matches))
+		}
+		data, _ := os.ReadFile(matches[0])
+		if !strings.Contains(string(data), "Timed out") {
+			t.Errorf("expected timeout marker in result, got %q", data)
+		}
+	})
+
+	t.Run("no timeout means no deadline", func(t *testing.T) {
+		rec := &recordingProvider{response: "ok"}
+		cfg := &ExecutorConfig{
+			Provider: rec,
+			Results:  t.TempDir(),
+			Logger:   slog.Default(),
+		}
+		job := &CronJob{Name: "n", Schedule: "0 9 * * *", Prompt: "p"}
+		Execute(context.Background(), cfg, job)
+		if rec.hadDeadline {
+			t.Errorf("expected no deadline when Timeout is zero")
+		}
+	})
+
+	t.Run("timeout set means provider sees deadline", func(t *testing.T) {
+		rec := &recordingProvider{response: "ok"}
+		cfg := &ExecutorConfig{
+			Provider: rec,
+			Results:  t.TempDir(),
+			Logger:   slog.Default(),
+		}
+		job := &CronJob{Name: "n", Schedule: "0 9 * * *", Timeout: time.Second, Prompt: "p"}
+		Execute(context.Background(), cfg, job)
+		if !rec.hadDeadline {
+			t.Errorf("expected provider ctx to carry a deadline")
+		}
+	})
 }

--- a/pkg/cron/executor_test.go
+++ b/pkg/cron/executor_test.go
@@ -2,6 +2,7 @@ package cron
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -26,45 +27,49 @@ func (m *mockProvider) Generate(_ context.Context, _ *provider.GenerateParams) (
 	}, nil
 }
 
+type errorProvider struct {
+	err error
+}
+
+func (p *errorProvider) Generate(_ context.Context, _ *provider.GenerateParams) (*provider.Response, error) {
+	return nil, p.err
+}
+
 func TestExecute(t *testing.T) {
-	resultsDir := t.TempDir()
-	cfg := &ExecutorConfig{
-		Provider: &mockProvider{response: "Here is your summary"},
-		Results:  resultsDir,
-		Logger:   slog.Default(),
-	}
+	t.Run("writes result file with scheduled source frontmatter", func(t *testing.T) {
+		resultsDir := t.TempDir()
+		cfg := &ExecutorConfig{
+			Provider: &mockProvider{response: "Here is your summary"},
+			Results:  resultsDir,
+			Logger:   slog.Default(),
+		}
+		job := &CronJob{Name: "daily-summary", Schedule: "0 9 * * *", Prompt: "Summarize my day"}
 
-	job := &CronJob{
-		Name:     "daily-summary",
-		Schedule: "0 9 * * *",
-		Prompt:   "Summarize my day",
-	}
+		Execute(context.Background(), cfg, job)
 
-	Execute(context.Background(), cfg, job)
+		matches, err := filepath.Glob(filepath.Join(resultsDir, "daily-summary-*.md"))
+		if err != nil {
+			t.Fatalf("Glob failed: %v", err)
+		}
+		if len(matches) != 1 {
+			t.Fatalf("expected 1 result file, got %d", len(matches))
+		}
+		data, err := os.ReadFile(matches[0])
+		if err != nil {
+			t.Fatalf("ReadFile failed: %v", err)
+		}
+		body := string(data)
+		for _, want := range []string{"source: scheduled", "status: success", "started_at:", "duration:", "Here is your summary"} {
+			if !strings.Contains(body, want) {
+				t.Errorf("output missing %q:\n%s", want, body)
+			}
+		}
 
-	matches, err := filepath.Glob(filepath.Join(resultsDir, "daily-summary-*.md"))
-	if err != nil {
-		t.Fatalf("Glob failed: %v", err)
-	}
-	if len(matches) != 1 {
-		t.Fatalf("expected 1 result file, got %d", len(matches))
-	}
-
-	data, err := os.ReadFile(matches[0])
-	if err != nil {
-		t.Fatalf("ReadFile failed: %v", err)
-	}
-	if string(data) != "Here is your summary" {
-		t.Errorf("expected result content, got %q", data)
-	}
-
-	filename := filepath.Base(matches[0])
-	if !strings.HasPrefix(filename, "daily-summary-") {
-		t.Errorf("expected filename to start with daily-summary-, got %q", filename)
-	}
-	if !strings.HasSuffix(filename, ".md") {
-		t.Errorf("expected filename to end with .md, got %q", filename)
-	}
+		filename := filepath.Base(matches[0])
+		if !strings.HasPrefix(filename, "daily-summary-") || !strings.HasSuffix(filename, ".md") {
+			t.Errorf("unexpected filename %q", filename)
+		}
+	})
 }
 
 type blockingProvider struct{}
@@ -75,12 +80,13 @@ func (p *blockingProvider) Generate(ctx context.Context, _ *provider.GeneratePar
 }
 
 type recordingProvider struct {
+	deadline    time.Time
 	hadDeadline bool
 	response    string
 }
 
 func (p *recordingProvider) Generate(ctx context.Context, _ *provider.GenerateParams) (*provider.Response, error) {
-	_, p.hadDeadline = ctx.Deadline()
+	p.deadline, p.hadDeadline = ctx.Deadline()
 	return &provider.Response{
 		Message: provider.Message{Role: provider.RoleModel, Content: p.response},
 	}, nil
@@ -117,8 +123,12 @@ func TestExecuteTimeout(t *testing.T) {
 			t.Fatalf("expected 1 result file, got %d", len(matches))
 		}
 		data, _ := os.ReadFile(matches[0])
-		if !strings.Contains(string(data), "Timed out") {
-			t.Errorf("expected timeout marker in result, got %q", data)
+		body := string(data)
+		if !strings.Contains(body, "Timed out") {
+			t.Errorf("expected timeout marker in result, got %q", body)
+		}
+		if !strings.Contains(body, "status: timeout") {
+			t.Errorf("expected status: timeout, got %q", body)
 		}
 	})
 
@@ -147,6 +157,125 @@ func TestExecuteTimeout(t *testing.T) {
 		Execute(context.Background(), cfg, job)
 		if !rec.hadDeadline {
 			t.Errorf("expected provider ctx to carry a deadline")
+		}
+	})
+}
+
+func TestExecuteTest(t *testing.T) {
+	t.Run("streams stdout, records manual source, returns exit 0", func(t *testing.T) {
+		resultsDir := t.TempDir()
+		cfg := &ExecutorConfig{
+			Provider: &mockProvider{response: "streamed output"},
+			Results:  resultsDir,
+			Logger:   slog.Default(),
+		}
+		job := &CronJob{Name: "manual", Schedule: "0 9 * * *", Prompt: "run now"}
+
+		var stdoutCapture, stderrCapture strings.Builder
+		res := ExecuteTest(context.Background(), cfg, job, TestOptions{
+			OnStdout: func(s string) { stdoutCapture.WriteString(s) },
+			OnStderr: func(s string) { stderrCapture.WriteString(s) },
+		})
+
+		if res.ExitCode != 0 {
+			t.Errorf("expected exit 0, got %d", res.ExitCode)
+		}
+		if res.Duration <= 0 {
+			t.Errorf("expected positive duration, got %s", res.Duration)
+		}
+		if stdoutCapture.String() != "streamed output" {
+			t.Errorf("stdout capture mismatch: %q", stdoutCapture.String())
+		}
+		if stderrCapture.String() != "" {
+			t.Errorf("expected empty stderr, got %q", stderrCapture.String())
+		}
+
+		matches, _ := filepath.Glob(filepath.Join(resultsDir, "manual-*.md"))
+		if len(matches) != 1 {
+			t.Fatalf("expected 1 result file, got %d", len(matches))
+		}
+		data, _ := os.ReadFile(matches[0])
+		body := string(data)
+		if !strings.Contains(body, "source: manual") {
+			t.Errorf("expected source: manual, got %q", body)
+		}
+		if !strings.Contains(body, "status: success") {
+			t.Errorf("expected status: success, got %q", body)
+		}
+	})
+
+	t.Run("error streams to stderr and returns non-zero", func(t *testing.T) {
+		cfg := &ExecutorConfig{
+			Provider: &errorProvider{err: errors.New("boom")},
+			Results:  t.TempDir(),
+			Logger:   slog.Default(),
+		}
+		job := &CronJob{Name: "err", Schedule: "0 9 * * *", Prompt: "p"}
+
+		var stderrCapture strings.Builder
+		res := ExecuteTest(context.Background(), cfg, job, TestOptions{
+			OnStderr: func(s string) { stderrCapture.WriteString(s) },
+		})
+
+		if res.ExitCode == 0 {
+			t.Errorf("expected non-zero exit, got 0")
+		}
+		if !strings.Contains(stderrCapture.String(), "boom") {
+			t.Errorf("expected error surfaced on stderr, got %q", stderrCapture.String())
+		}
+	})
+}
+
+func TestExecuteTestTimeoutPrecedence(t *testing.T) {
+	t.Run("override takes precedence over job timeout and default", func(t *testing.T) {
+		rec := &recordingProvider{response: "ok"}
+		cfg := &ExecutorConfig{Provider: rec, Results: t.TempDir(), Logger: slog.Default()}
+		job := &CronJob{Name: "n", Schedule: "0 9 * * *", Timeout: time.Hour, Prompt: "p"}
+
+		before := time.Now()
+		ExecuteTest(context.Background(), cfg, job, TestOptions{Timeout: 2 * time.Second})
+
+		if !rec.hadDeadline {
+			t.Fatal("expected a deadline")
+		}
+		budget := rec.deadline.Sub(before)
+		if budget > 10*time.Second {
+			t.Errorf("override ignored; deadline budget = %s", budget)
+		}
+	})
+
+	t.Run("job timeout used when no override", func(t *testing.T) {
+		rec := &recordingProvider{response: "ok"}
+		cfg := &ExecutorConfig{Provider: rec, Results: t.TempDir(), Logger: slog.Default()}
+		job := &CronJob{Name: "n", Schedule: "0 9 * * *", Timeout: 2 * time.Second, Prompt: "p"}
+
+		before := time.Now()
+		ExecuteTest(context.Background(), cfg, job, TestOptions{})
+
+		if !rec.hadDeadline {
+			t.Fatal("expected a deadline")
+		}
+		budget := rec.deadline.Sub(before)
+		if budget > 10*time.Second || budget < time.Second {
+			t.Errorf("job timeout not applied; budget = %s", budget)
+		}
+	})
+
+	t.Run("5-minute default when neither is set", func(t *testing.T) {
+		rec := &recordingProvider{response: "ok"}
+		cfg := &ExecutorConfig{Provider: rec, Results: t.TempDir(), Logger: slog.Default()}
+		job := &CronJob{Name: "n", Schedule: "0 9 * * *", Prompt: "p"}
+
+		before := time.Now()
+		ExecuteTest(context.Background(), cfg, job, TestOptions{})
+
+		if !rec.hadDeadline {
+			t.Fatal("expected a deadline")
+		}
+		budget := rec.deadline.Sub(before)
+		// default is 5m; should be clearly > 1 minute and ≤ 5 minutes.
+		if budget < time.Minute || budget > 6*time.Minute {
+			t.Errorf("default timeout not ~5m; budget = %s", budget)
 		}
 	})
 }

--- a/pkg/cron/frontmatter.go
+++ b/pkg/cron/frontmatter.go
@@ -1,0 +1,109 @@
+package cron
+
+import (
+	"fmt"
+	"os"
+	"slices"
+	"strings"
+
+	"go.yaml.in/yaml/v3"
+)
+
+// SetFrontmatterField rewrites a single YAML frontmatter field in the file at path
+// without reserializing the whole document. If the field exists, its value is
+// replaced in place, preserving leading indentation and any trailing inline
+// comment. If the field is absent, it is appended at the end of the frontmatter
+// block. Unrelated fields, field order, body, and surrounding whitespace are
+// untouched.
+func SetFrontmatterField(path, key string, value any) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("cron: read %s: %w", path, err)
+	}
+
+	content := string(data)
+	if !strings.HasPrefix(content, "---\n") {
+		return fmt.Errorf("cron: missing frontmatter delimiter")
+	}
+	rest := content[4:]
+	idx := strings.Index(rest, "\n---")
+	if idx < 0 {
+		return fmt.Errorf("cron: missing closing frontmatter delimiter")
+	}
+
+	frontmatter := rest[:idx]
+	trailer := rest[idx:] // begins with "\n---"
+
+	scalar, err := marshalScalar(value)
+	if err != nil {
+		return err
+	}
+
+	newFrontmatter := replaceOrAppendField(frontmatter, key, scalar)
+
+	newContent := "---\n" + newFrontmatter + trailer
+	if err := os.WriteFile(path, []byte(newContent), 0o644); err != nil { //nolint:gosec // caller-provided path, writing alongside the file we just read
+		return fmt.Errorf("cron: write %s: %w", path, err)
+	}
+	return nil
+}
+
+func replaceOrAppendField(frontmatter, key, scalar string) string {
+	lines := strings.Split(frontmatter, "\n")
+	keyPrefix := key + ":"
+
+	for i, line := range lines {
+		trimmed := strings.TrimLeft(line, " \t")
+		if !strings.HasPrefix(trimmed, keyPrefix) {
+			continue
+		}
+		after := trimmed[len(keyPrefix):]
+		if after != "" && after[0] != ' ' && after[0] != '\t' && after[0] != '#' {
+			// e.g. "keysuffix:" shares the prefix but is a different key.
+			continue
+		}
+		indent := line[:len(line)-len(trimmed)]
+		comment := extractInlineComment(after)
+		newLine := indent + key + ": " + scalar
+		if comment != "" {
+			newLine = newLine + " " + comment
+		}
+		lines[i] = newLine
+		return strings.Join(lines, "\n")
+	}
+
+	// Field absent: append at the end of the frontmatter. If the block ends
+	// with one or more blank lines, insert before them so any trailing
+	// whitespace is preserved.
+	insertAt := len(lines)
+	for insertAt > 0 && strings.TrimSpace(lines[insertAt-1]) == "" {
+		insertAt--
+	}
+	lines = slices.Insert(lines, insertAt, key+": "+scalar)
+	return strings.Join(lines, "\n")
+}
+
+// extractInlineComment returns the trailing " # ..." comment in value (including
+// the leading '#'), or "" if none is present. Only whitespace-preceded '#' is
+// treated as a comment to avoid mangling quoted scalars that contain '#'.
+func extractInlineComment(valueAndMaybeComment string) string {
+	for i := 0; i < len(valueAndMaybeComment); i++ {
+		c := valueAndMaybeComment[i]
+		if c != '#' {
+			continue
+		}
+		if i == 0 || valueAndMaybeComment[i-1] == ' ' || valueAndMaybeComment[i-1] == '\t' {
+			return strings.TrimRight(valueAndMaybeComment[i:], " \t")
+		}
+	}
+	return ""
+}
+
+// marshalScalar renders value as a single-line YAML scalar.
+func marshalScalar(value any) (string, error) {
+	data, err := yaml.Marshal(value)
+	if err != nil {
+		return "", fmt.Errorf("cron: marshal value: %w", err)
+	}
+	return strings.TrimRight(string(data), "\n"), nil
+}

--- a/pkg/cron/frontmatter_test.go
+++ b/pkg/cron/frontmatter_test.go
@@ -1,0 +1,159 @@
+package cron
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSetFrontmatterField(t *testing.T) {
+	cases := []struct {
+		name  string
+		in    string
+		key   string
+		value any
+		want  string
+	}{
+		{
+			name:  "update existing field preserves order and body",
+			in:    "---\nname: foo\ncron: \"0 9 * * *\"\nsuspended: false\n---\nDo a thing\n",
+			key:   "suspended",
+			value: true,
+			want:  "---\nname: foo\ncron: \"0 9 * * *\"\nsuspended: true\n---\nDo a thing\n",
+		},
+		{
+			name:  "add missing field appends at end of frontmatter",
+			in:    "---\nname: foo\ncron: \"0 9 * * *\"\n---\nbody\n",
+			key:   "suspended",
+			value: true,
+			want:  "---\nname: foo\ncron: \"0 9 * * *\"\nsuspended: true\n---\nbody\n",
+		},
+		{
+			name:  "preserves inline comment on existing field",
+			in:    "---\nname: foo\ncron: \"0 9 * * *\"\nsuspended: false # set by CI\n---\nbody\n",
+			key:   "suspended",
+			value: true,
+			want:  "---\nname: foo\ncron: \"0 9 * * *\"\nsuspended: true # set by CI\n---\nbody\n",
+		},
+		{
+			name:  "preserves unrelated fields",
+			in:    "---\nname: foo\ncron: \"0 9 * * *\"\ntimeout: 30m\ndescription: whatever\n---\nbody\n",
+			key:   "suspended",
+			value: true,
+			want:  "---\nname: foo\ncron: \"0 9 * * *\"\ntimeout: 30m\ndescription: whatever\nsuspended: true\n---\nbody\n",
+		},
+		{
+			name:  "preserves trailing blank line in frontmatter when appending",
+			in:    "---\nname: foo\ncron: \"0 9 * * *\"\n\n---\nbody\n",
+			key:   "suspended",
+			value: true,
+			want:  "---\nname: foo\ncron: \"0 9 * * *\"\nsuspended: true\n\n---\nbody\n",
+		},
+		{
+			name:  "update preserves indentation",
+			in:    "---\n  name: foo\n  cron: \"0 9 * * *\"\n  suspended: false\n---\nbody\n",
+			key:   "suspended",
+			value: true,
+			want:  "---\n  name: foo\n  cron: \"0 9 * * *\"\n  suspended: true\n---\nbody\n",
+		},
+		{
+			name:  "body with trailing content is untouched",
+			in:    "---\nname: foo\ncron: \"0 9 * * *\"\n---\nline one\nline two\n",
+			key:   "suspended",
+			value: false,
+			want:  "---\nname: foo\ncron: \"0 9 * * *\"\nsuspended: false\n---\nline one\nline two\n",
+		},
+		{
+			name:  "toggle true to false",
+			in:    "---\nname: foo\ncron: \"0 9 * * *\"\nsuspended: true\n---\nbody\n",
+			key:   "suspended",
+			value: false,
+			want:  "---\nname: foo\ncron: \"0 9 * * *\"\nsuspended: false\n---\nbody\n",
+		},
+		{
+			name:  "keys with similar prefix are not confused",
+			in:    "---\nname: foo\ncron: \"0 9 * * *\"\nsuspended_at: 2026-01-01\n---\nbody\n",
+			key:   "suspended",
+			value: true,
+			want:  "---\nname: foo\ncron: \"0 9 * * *\"\nsuspended_at: 2026-01-01\nsuspended: true\n---\nbody\n",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "job.md")
+			if err := os.WriteFile(path, []byte(tc.in), 0o644); err != nil {
+				t.Fatalf("write: %v", err)
+			}
+			if err := SetFrontmatterField(path, tc.key, tc.value); err != nil {
+				t.Fatalf("SetFrontmatterField: %v", err)
+			}
+			got, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("read: %v", err)
+			}
+			if string(got) != tc.want {
+				t.Errorf("content mismatch:\n--- got ---\n%s\n--- want ---\n%s", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSetFrontmatterFieldErrors(t *testing.T) {
+	t.Run("missing file", func(t *testing.T) {
+		dir := t.TempDir()
+		err := SetFrontmatterField(filepath.Join(dir, "no-such-file.md"), "suspended", true)
+		if err == nil {
+			t.Fatal("expected error for missing file")
+		}
+	})
+
+	t.Run("no opening delimiter", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "bad.md")
+		if err := os.WriteFile(path, []byte("name: foo\ncron: \"0 9 * * *\"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := SetFrontmatterField(path, "suspended", true); err == nil {
+			t.Fatal("expected error for missing frontmatter delimiter")
+		}
+	})
+
+	t.Run("no closing delimiter", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "bad.md")
+		if err := os.WriteFile(path, []byte("---\nname: foo\ncron: \"0 9 * * *\"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := SetFrontmatterField(path, "suspended", true); err == nil {
+			t.Fatal("expected error for missing closing delimiter")
+		}
+	})
+}
+
+func TestSetFrontmatterFieldRoundTripsThroughParse(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "job.md")
+	original := "---\nname: demo\ncron: \"*/5 * * * *\"\n---\nGenerate a summary.\n"
+	if err := os.WriteFile(path, []byte(original), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := SetFrontmatterField(path, "suspended", true); err != nil {
+		t.Fatalf("SetFrontmatterField: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	job, err := Parse(data)
+	if err != nil {
+		t.Fatalf("Parse after set: %v", err)
+	}
+	if !job.Suspended {
+		t.Errorf("expected Suspended=true after set, got false")
+	}
+	if job.Name != "demo" || job.Schedule != "*/5 * * * *" || job.Prompt != "Generate a summary." {
+		t.Errorf("parsed fields changed unexpectedly: %+v", job)
+	}
+}

--- a/pkg/cron/scheduler.go
+++ b/pkg/cron/scheduler.go
@@ -43,14 +43,21 @@ func (s *Scheduler) LoadAndStart(ctx context.Context) error {
 		s.logger.Warn("cron load error", "error", err)
 	}
 
+	registered := 0
 	for _, job := range jobs {
+		if job.Suspended {
+			s.logger.Info("cron job suspended", "name", job.Name)
+			continue
+		}
 		if err := s.addJob(ctx, job); err != nil {
 			s.logger.Error("failed to add cron job", "name", job.Name, "error", err)
+			continue
 		}
+		registered++
 	}
 
 	s.scheduler.Start()
-	s.logger.Info("cron scheduler started", "jobs", len(jobs))
+	s.logger.Info("cron scheduler started", "jobs", registered)
 	return nil
 }
 
@@ -85,13 +92,20 @@ func (s *Scheduler) Reload(ctx context.Context) error {
 		s.logger.Warn("cron reload error", "error", err)
 	}
 
+	registered := 0
 	for _, job := range jobs {
+		if job.Suspended {
+			s.logger.Info("cron job suspended", "name", job.Name)
+			continue
+		}
 		if err := s.addJob(ctx, job); err != nil {
 			s.logger.Error("failed to add cron job on reload", "name", job.Name, "error", err)
+			continue
 		}
+		registered++
 	}
 
-	s.logger.Info("cron scheduler reloaded", "jobs", len(jobs))
+	s.logger.Info("cron scheduler reloaded", "jobs", registered)
 	return nil
 }
 

--- a/pkg/cron/scheduler.go
+++ b/pkg/cron/scheduler.go
@@ -33,6 +33,7 @@ type jobEntry struct {
 	name     string
 	schedule string
 	prompt   string
+	timeout  time.Duration
 	status   JobStatus
 	errMsg   string
 	gJob     gocron.Job
@@ -95,11 +96,13 @@ func (s *Scheduler) rebuildEntries(ctx context.Context) int {
 		case r.Job.Suspended:
 			e.schedule = r.Job.Schedule
 			e.prompt = r.Job.Prompt
+			e.timeout = r.Job.Timeout
 			e.status = StatusSuspended
 			s.logger.Info("cron job suspended", "name", e.name)
 		default:
 			e.schedule = r.Job.Schedule
 			e.prompt = r.Job.Prompt
+			e.timeout = r.Job.Timeout
 			gJob, err := s.addJob(ctx, r.Job)
 			if err != nil {
 				e.status = StatusError
@@ -136,6 +139,7 @@ type JobInfo struct {
 	Schedule string    `json:"schedule,omitempty"`
 	Status   JobStatus `json:"status"`
 	Prompt   string    `json:"prompt,omitempty"`
+	Timeout  string    `json:"timeout,omitempty"`
 	NextRun  string    `json:"next_run,omitempty"`
 	LastRun  string    `json:"last_run,omitempty"`
 	Error    string    `json:"error,omitempty"`
@@ -154,6 +158,9 @@ func (s *Scheduler) ListJobs() []JobInfo {
 			Status:   e.status,
 			Prompt:   e.prompt,
 			Error:    e.errMsg,
+		}
+		if e.timeout > 0 {
+			info.Timeout = e.timeout.String()
 		}
 		if e.gJob != nil {
 			if next, err := e.gJob.NextRun(); err == nil && !next.IsZero() {

--- a/pkg/cron/scheduler.go
+++ b/pkg/cron/scheduler.go
@@ -10,6 +10,15 @@ import (
 	"github.com/go-co-op/gocron/v2"
 )
 
+// JobStatus classifies a job's runtime state in the scheduler.
+type JobStatus string
+
+const (
+	StatusRunning   JobStatus = "running"
+	StatusSuspended JobStatus = "suspended"
+	StatusError     JobStatus = "error"
+)
+
 // Scheduler manages cron jobs using gocron.
 type Scheduler struct {
 	scheduler gocron.Scheduler
@@ -17,6 +26,16 @@ type Scheduler struct {
 	execCfg   *ExecutorConfig
 	logger    *slog.Logger
 	mu        sync.Mutex
+	entries   []*jobEntry
+}
+
+type jobEntry struct {
+	name     string
+	schedule string
+	prompt   string
+	status   JobStatus
+	errMsg   string
+	gJob     gocron.Job
 }
 
 // NewScheduler creates a new cron scheduler.
@@ -38,41 +57,10 @@ func (s *Scheduler) LoadAndStart(ctx context.Context) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	jobs, errs := LoadAll(s.crons)
-	for _, err := range errs {
-		s.logger.Warn("cron load error", "error", err)
-	}
-
-	registered := 0
-	for _, job := range jobs {
-		if job.Suspended {
-			s.logger.Info("cron job suspended", "name", job.Name)
-			continue
-		}
-		if err := s.addJob(ctx, job); err != nil {
-			s.logger.Error("failed to add cron job", "name", job.Name, "error", err)
-			continue
-		}
-		registered++
-	}
-
+	running := s.rebuildEntries(ctx)
 	s.scheduler.Start()
-	s.logger.Info("cron scheduler started", "jobs", registered)
+	s.logger.Info("cron scheduler started", "jobs", running)
 	return nil
-}
-
-func (s *Scheduler) addJob(ctx context.Context, job *CronJob) error {
-	// Capture job for closure
-	j := job
-	_, err := s.scheduler.NewJob(
-		gocron.CronJob(j.Schedule, false),
-		gocron.NewTask(func() {
-			Execute(ctx, s.execCfg, j)
-		}),
-		gocron.WithName(j.Name),
-		gocron.WithTags(j.Schedule),
-	)
-	return err
 }
 
 // Reload removes all jobs and re-loads from home.
@@ -80,69 +68,108 @@ func (s *Scheduler) Reload(ctx context.Context) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	// Remove all existing jobs
+	running := s.rebuildEntries(ctx)
+	s.logger.Info("cron scheduler reloaded", "jobs", running)
+	return nil
+}
+
+// rebuildEntries drops every registered gocron job and re-classifies the
+// markdown directory. Must be called with s.mu held. Returns the count of
+// jobs that ended up registered with gocron.
+func (s *Scheduler) rebuildEntries(ctx context.Context) int {
 	for _, j := range s.scheduler.Jobs() {
 		if err := s.scheduler.RemoveJob(j.ID()); err != nil {
 			s.logger.Warn("failed to remove job", "id", j.ID(), "error", err)
 		}
 	}
+	s.entries = nil
 
-	jobs, errs := LoadAll(s.crons)
-	for _, err := range errs {
-		s.logger.Warn("cron reload error", "error", err)
-	}
-
-	registered := 0
-	for _, job := range jobs {
-		if job.Suspended {
-			s.logger.Info("cron job suspended", "name", job.Name)
-			continue
+	running := 0
+	for _, r := range LoadAllResults(s.crons) {
+		e := &jobEntry{name: r.Name}
+		switch {
+		case r.Err != nil:
+			e.status = StatusError
+			e.errMsg = r.Err.Error()
+			s.logger.Warn("cron load error", "name", e.name, "error", e.errMsg)
+		case r.Job.Suspended:
+			e.schedule = r.Job.Schedule
+			e.prompt = r.Job.Prompt
+			e.status = StatusSuspended
+			s.logger.Info("cron job suspended", "name", e.name)
+		default:
+			e.schedule = r.Job.Schedule
+			e.prompt = r.Job.Prompt
+			gJob, err := s.addJob(ctx, r.Job)
+			if err != nil {
+				e.status = StatusError
+				e.errMsg = err.Error()
+				s.logger.Error("failed to register cron job", "name", e.name, "error", err)
+			} else {
+				e.status = StatusRunning
+				e.gJob = gJob
+				running++
+			}
 		}
-		if err := s.addJob(ctx, job); err != nil {
-			s.logger.Error("failed to add cron job on reload", "name", job.Name, "error", err)
-			continue
-		}
-		registered++
+		s.entries = append(s.entries, e)
 	}
-
-	s.logger.Info("cron scheduler reloaded", "jobs", registered)
-	return nil
+	return running
 }
 
-// JobInfo holds runtime information about a scheduled job.
+func (s *Scheduler) addJob(ctx context.Context, job *CronJob) (gocron.Job, error) {
+	j := job
+	gJob, err := s.scheduler.NewJob(
+		gocron.CronJob(j.Schedule, false),
+		gocron.NewTask(func() {
+			Execute(ctx, s.execCfg, j)
+		}),
+		gocron.WithName(j.Name),
+		gocron.WithTags(j.Schedule),
+	)
+	return gJob, err
+}
+
+// JobInfo holds runtime information about a known job (running, suspended, or
+// error). Fields are omitted from JSON when empty to keep the wire format lean.
 type JobInfo struct {
-	Name     string `json:"name"`
-	Schedule string `json:"schedule"`
-	NextRun  string `json:"next_run"`
-	LastRun  string `json:"last_run,omitempty"`
+	Name     string    `json:"name"`
+	Schedule string    `json:"schedule,omitempty"`
+	Status   JobStatus `json:"status"`
+	Prompt   string    `json:"prompt,omitempty"`
+	NextRun  string    `json:"next_run,omitempty"`
+	LastRun  string    `json:"last_run,omitempty"`
+	Error    string    `json:"error,omitempty"`
 }
 
-// ListJobs returns runtime info for all scheduled jobs.
+// ListJobs returns the full job state: running, suspended, and error jobs.
 func (s *Scheduler) ListJobs() []JobInfo {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	infos := make([]JobInfo, 0, len(s.scheduler.Jobs()))
-	for _, j := range s.scheduler.Jobs() {
+	infos := make([]JobInfo, 0, len(s.entries))
+	for _, e := range s.entries {
 		info := JobInfo{
-			Name: j.Name(),
+			Name:     e.name,
+			Schedule: e.schedule,
+			Status:   e.status,
+			Prompt:   e.prompt,
+			Error:    e.errMsg,
 		}
-		if next, err := j.NextRun(); err == nil {
-			info.NextRun = next.Format(time.RFC3339)
-		}
-		if last, err := j.LastRun(); err == nil && !last.IsZero() {
-			info.LastRun = last.Format(time.RFC3339)
-		}
-		// Extract schedule string from tags if available
-		if tags := j.Tags(); len(tags) > 0 {
-			info.Schedule = tags[0]
+		if e.gJob != nil {
+			if next, err := e.gJob.NextRun(); err == nil && !next.IsZero() {
+				info.NextRun = next.Format(time.RFC3339)
+			}
+			if last, err := e.gJob.LastRun(); err == nil && !last.IsZero() {
+				info.LastRun = last.Format(time.RFC3339)
+			}
 		}
 		infos = append(infos, info)
 	}
 	return infos
 }
 
-// JobCount returns the number of registered jobs.
+// JobCount returns the number of jobs currently registered with gocron
+// (i.e. running jobs). Suspended and error jobs are excluded.
 func (s *Scheduler) JobCount() int {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/pkg/cron/scheduler_test.go
+++ b/pkg/cron/scheduler_test.go
@@ -95,6 +95,74 @@ func TestSchedulerReloadRemovesDeletedJobs(t *testing.T) {
 	}
 }
 
+func TestSchedulerSuspended(t *testing.T) {
+	t.Run("does not register suspended jobs on LoadAndStart", func(t *testing.T) {
+		dir := t.TempDir()
+		os.WriteFile(filepath.Join(dir, "active.md"), []byte("---\nname: active\ncron: \"0 9 * * *\"\n---\nprompt"), 0o644)
+		os.WriteFile(filepath.Join(dir, "paused.md"), []byte("---\nname: paused\ncron: \"0 9 * * *\"\nsuspended: true\n---\nprompt"), 0o644)
+
+		s := newTestScheduler(t, dir)
+		defer s.Stop()
+
+		if err := s.LoadAndStart(context.Background()); err != nil {
+			t.Fatalf("LoadAndStart failed: %v", err)
+		}
+		if got := s.JobCount(); got != 1 {
+			t.Errorf("expected 1 registered job (suspended skipped), got %d", got)
+		}
+	})
+
+	t.Run("reload picks up a job when suspended flag flips to false", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "toggle.md")
+		os.WriteFile(path, []byte("---\nname: toggle\ncron: \"0 9 * * *\"\nsuspended: true\n---\nprompt"), 0o644)
+
+		s := newTestScheduler(t, dir)
+		defer s.Stop()
+
+		if err := s.LoadAndStart(context.Background()); err != nil {
+			t.Fatalf("LoadAndStart failed: %v", err)
+		}
+		if got := s.JobCount(); got != 0 {
+			t.Errorf("expected 0 registered jobs while suspended, got %d", got)
+		}
+
+		os.WriteFile(path, []byte("---\nname: toggle\ncron: \"0 9 * * *\"\n---\nprompt"), 0o644)
+
+		if err := s.Reload(context.Background()); err != nil {
+			t.Fatalf("Reload failed: %v", err)
+		}
+		if got := s.JobCount(); got != 1 {
+			t.Errorf("expected 1 registered job after resume, got %d", got)
+		}
+	})
+
+	t.Run("reload drops a job when suspended flag flips to true", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "toggle.md")
+		os.WriteFile(path, []byte("---\nname: toggle\ncron: \"0 9 * * *\"\n---\nprompt"), 0o644)
+
+		s := newTestScheduler(t, dir)
+		defer s.Stop()
+
+		if err := s.LoadAndStart(context.Background()); err != nil {
+			t.Fatalf("LoadAndStart failed: %v", err)
+		}
+		if got := s.JobCount(); got != 1 {
+			t.Errorf("expected 1 registered job, got %d", got)
+		}
+
+		os.WriteFile(path, []byte("---\nname: toggle\ncron: \"0 9 * * *\"\nsuspended: true\n---\nprompt"), 0o644)
+
+		if err := s.Reload(context.Background()); err != nil {
+			t.Fatalf("Reload failed: %v", err)
+		}
+		if got := s.JobCount(); got != 0 {
+			t.Errorf("expected 0 registered jobs after suspend, got %d", got)
+		}
+	})
+}
+
 func TestSchedulerEmptyLoad(t *testing.T) {
 	dir := t.TempDir()
 	s := newTestScheduler(t, dir)

--- a/pkg/cron/scheduler_test.go
+++ b/pkg/cron/scheduler_test.go
@@ -163,6 +163,114 @@ func TestSchedulerSuspended(t *testing.T) {
 	})
 }
 
+func TestSchedulerListJobs(t *testing.T) {
+	t.Run("classifies running, suspended, and error jobs", func(t *testing.T) {
+		dir := t.TempDir()
+		os.WriteFile(filepath.Join(dir, "active.md"), []byte("---\nname: active\ncron: \"0 9 * * *\"\n---\nprompt-active"), 0o644)
+		os.WriteFile(filepath.Join(dir, "paused.md"), []byte("---\nname: paused\ncron: \"0 9 * * *\"\nsuspended: true\n---\nprompt-paused"), 0o644)
+		os.WriteFile(filepath.Join(dir, "broken.md"), []byte("---\nname: broken\n---\nno schedule"), 0o644)
+
+		s := newTestScheduler(t, dir)
+		defer s.Stop()
+		if err := s.LoadAndStart(context.Background()); err != nil {
+			t.Fatalf("LoadAndStart: %v", err)
+		}
+
+		infos := s.ListJobs()
+		if len(infos) != 3 {
+			t.Fatalf("expected 3 entries, got %d", len(infos))
+		}
+
+		byName := map[string]JobInfo{}
+		for _, i := range infos {
+			byName[i.Name] = i
+		}
+		if got := byName["active"].Status; got != StatusRunning {
+			t.Errorf("active: expected running, got %q", got)
+		}
+		if got := byName["active"].NextRun; got == "" {
+			t.Errorf("active: expected NextRun to be populated")
+		}
+		if got := byName["paused"].Status; got != StatusSuspended {
+			t.Errorf("paused: expected suspended, got %q", got)
+		}
+		if got := byName["paused"].NextRun; got != "" {
+			t.Errorf("paused: expected empty NextRun, got %q", got)
+		}
+		if got := byName["broken"].Status; got != StatusError {
+			t.Errorf("broken: expected error, got %q", got)
+		}
+		if byName["broken"].Error == "" {
+			t.Errorf("broken: expected non-empty error reason")
+		}
+	})
+
+	t.Run("reload reclassifies running → suspended → error → running", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "toggle.md")
+		os.WriteFile(path, []byte("---\nname: toggle\ncron: \"0 9 * * *\"\n---\nprompt"), 0o644)
+
+		s := newTestScheduler(t, dir)
+		defer s.Stop()
+		if err := s.LoadAndStart(context.Background()); err != nil {
+			t.Fatalf("LoadAndStart: %v", err)
+		}
+		if got := firstStatus(t, s.ListJobs()); got != StatusRunning {
+			t.Fatalf("stage1: expected running, got %q", got)
+		}
+
+		os.WriteFile(path, []byte("---\nname: toggle\ncron: \"0 9 * * *\"\nsuspended: true\n---\nprompt"), 0o644)
+		if err := s.Reload(context.Background()); err != nil {
+			t.Fatalf("Reload: %v", err)
+		}
+		if got := firstStatus(t, s.ListJobs()); got != StatusSuspended {
+			t.Fatalf("stage2: expected suspended, got %q", got)
+		}
+
+		os.WriteFile(path, []byte("---\nname: toggle\n---\nno schedule"), 0o644)
+		if err := s.Reload(context.Background()); err != nil {
+			t.Fatalf("Reload: %v", err)
+		}
+		if got := firstStatus(t, s.ListJobs()); got != StatusError {
+			t.Fatalf("stage3: expected error, got %q", got)
+		}
+
+		os.WriteFile(path, []byte("---\nname: toggle\ncron: \"0 9 * * *\"\n---\nprompt"), 0o644)
+		if err := s.Reload(context.Background()); err != nil {
+			t.Fatalf("Reload: %v", err)
+		}
+		if got := firstStatus(t, s.ListJobs()); got != StatusRunning {
+			t.Fatalf("stage4: expected running, got %q", got)
+		}
+	})
+
+	t.Run("broken job does not block other jobs", func(t *testing.T) {
+		dir := t.TempDir()
+		os.WriteFile(filepath.Join(dir, "ok.md"), []byte("---\nname: ok\ncron: \"0 9 * * *\"\n---\nprompt"), 0o644)
+		os.WriteFile(filepath.Join(dir, "broken.md"), []byte("---\nname: broken\n---\nno schedule"), 0o644)
+
+		s := newTestScheduler(t, dir)
+		defer s.Stop()
+		if err := s.LoadAndStart(context.Background()); err != nil {
+			t.Fatalf("LoadAndStart: %v", err)
+		}
+		if got := s.JobCount(); got != 1 {
+			t.Errorf("expected 1 running job, got %d", got)
+		}
+		if got := len(s.ListJobs()); got != 2 {
+			t.Errorf("expected 2 total entries, got %d", got)
+		}
+	})
+}
+
+func firstStatus(t *testing.T, infos []JobInfo) JobStatus {
+	t.Helper()
+	if len(infos) != 1 {
+		t.Fatalf("expected 1 job, got %d: %+v", len(infos), infos)
+	}
+	return infos[0].Status
+}
+
 func TestSchedulerEmptyLoad(t *testing.T) {
 	dir := t.TempDir()
 	s := newTestScheduler(t, dir)

--- a/pkg/daemon/client.go
+++ b/pkg/daemon/client.go
@@ -28,6 +28,20 @@ func sockPath() (string, error) {
 	return config.GlobalFilePath("wildgecu.sock")
 }
 
+// DialSocket opens a raw connection to the daemon Unix socket. Used by
+// streaming protocols (e.g. cron-test) that need to read/write NDJSON
+// directly rather than the single-request SendCommand flow.
+func DialSocket() (net.Conn, error) {
+	path, err := sockPath()
+	if err != nil {
+		return nil, err
+	}
+	if _, statErr := os.Stat(path); os.IsNotExist(statErr) {
+		return nil, fmt.Errorf("daemon not running (socket not found)")
+	}
+	return net.DialTimeout("unix", path, 5*time.Second)
+}
+
 // SendCommand sends a command to the running daemon and returns the response.
 func SendCommand(cmd string, args map[string]any) (*Response, error) {
 	path, err := sockPath()

--- a/pkg/daemon/cron.go
+++ b/pkg/daemon/cron.go
@@ -16,6 +16,19 @@ type cronSchedulerReloader interface {
 	Reload(ctx context.Context) error
 }
 
+// cronListSource is the subset of the scheduler the cron-list handler needs.
+type cronListSource interface {
+	ListJobs() []cron.JobInfo
+}
+
+// cronListHandler returns an RPC handler that surfaces the scheduler's full
+// job state (running, suspended, error) to the CLI.
+func cronListHandler(source cronListSource) CommandHandler {
+	return func(r *Request) (*Response, error) {
+		return &Response{OK: true, Payload: source.ListJobs()}, nil
+	}
+}
+
 // cronSuspendHandler returns an RPC handler that rewrites the `suspended` field
 // of a cron markdown file to true and triggers a scheduler reload.
 func cronSuspendHandler(ctx context.Context, cronsDir string, scheduler cronSchedulerReloader) CommandHandler {

--- a/pkg/daemon/cron.go
+++ b/pkg/daemon/cron.go
@@ -1,0 +1,76 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/ludusrusso/wildgecu/pkg/cron"
+)
+
+// cronSchedulerReloader is the subset of the scheduler the suspend/resume
+// handlers depend on. Kept small so tests can stub it.
+type cronSchedulerReloader interface {
+	Reload(ctx context.Context) error
+}
+
+// cronSuspendHandler returns an RPC handler that rewrites the `suspended` field
+// of a cron markdown file to true and triggers a scheduler reload.
+func cronSuspendHandler(ctx context.Context, cronsDir string, scheduler cronSchedulerReloader) CommandHandler {
+	return func(r *Request) (*Response, error) {
+		return setSuspended(ctx, cronsDir, scheduler, r, true)
+	}
+}
+
+// cronResumeHandler returns an RPC handler that rewrites the `suspended` field
+// to false and triggers a scheduler reload.
+func cronResumeHandler(ctx context.Context, cronsDir string, scheduler cronSchedulerReloader) CommandHandler {
+	return func(r *Request) (*Response, error) {
+		return setSuspended(ctx, cronsDir, scheduler, r, false)
+	}
+}
+
+func setSuspended(ctx context.Context, cronsDir string, scheduler cronSchedulerReloader, r *Request, target bool) (*Response, error) {
+	name, _ := r.Args["name"].(string)
+	if name == "" {
+		return &Response{OK: false, Error: "missing name argument"}, nil
+	}
+
+	path := filepath.Join(cronsDir, cron.Filename(name))
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return &Response{OK: false, Error: fmt.Sprintf("no job named %q", name)}, nil
+	}
+	if err != nil {
+		return &Response{OK: false, Error: fmt.Sprintf("read %s: %v", name, err)}, nil
+	}
+
+	job, err := cron.Parse(data)
+	if err != nil {
+		return &Response{OK: false, Error: fmt.Sprintf("job %q has config errors, fix the file first: %v", name, err)}, nil
+	}
+
+	if job.Suspended == target {
+		if target {
+			return &Response{OK: true, Payload: fmt.Sprintf("%s already suspended, no change", name)}, nil
+		}
+		return &Response{OK: true, Payload: fmt.Sprintf("%s already running, no change", name)}, nil
+	}
+
+	if err := cron.SetFrontmatterField(path, "suspended", target); err != nil {
+		return &Response{OK: false, Error: fmt.Sprintf("update %s: %v", name, err)}, nil
+	}
+
+	if scheduler != nil {
+		if err := scheduler.Reload(ctx); err != nil {
+			return &Response{OK: false, Error: fmt.Sprintf("reload: %v", err)}, nil
+		}
+	}
+
+	if target {
+		return &Response{OK: true, Payload: fmt.Sprintf("suspended %q", name)}, nil
+	}
+	return &Response{OK: true, Payload: fmt.Sprintf("resumed %q", name)}, nil
+}

--- a/pkg/daemon/cron_test.go
+++ b/pkg/daemon/cron_test.go
@@ -134,6 +134,43 @@ func TestCronSuspendHandler(t *testing.T) {
 	})
 }
 
+type stubListSource struct {
+	jobs []cron.JobInfo
+}
+
+func (s *stubListSource) ListJobs() []cron.JobInfo {
+	return s.jobs
+}
+
+func TestCronListHandler(t *testing.T) {
+	t.Run("returns scheduler state verbatim", func(t *testing.T) {
+		source := &stubListSource{jobs: []cron.JobInfo{
+			{Name: "a", Schedule: "0 9 * * *", Status: cron.StatusRunning, NextRun: "2026-04-20T09:00:00Z"},
+			{Name: "b", Schedule: "0 9 * * *", Status: cron.StatusSuspended},
+			{Name: "c", Status: cron.StatusError, Error: "missing schedule"},
+		}}
+
+		h := cronListHandler(source)
+		resp, err := h(&Request{})
+		if err != nil {
+			t.Fatalf("handler error: %v", err)
+		}
+		if !resp.OK {
+			t.Fatalf("expected OK, got error: %s", resp.Error)
+		}
+		got, ok := resp.Payload.([]cron.JobInfo)
+		if !ok {
+			t.Fatalf("payload type = %T, want []cron.JobInfo", resp.Payload)
+		}
+		if len(got) != 3 {
+			t.Fatalf("got %d jobs, want 3", len(got))
+		}
+		if got[0].Status != cron.StatusRunning || got[1].Status != cron.StatusSuspended || got[2].Status != cron.StatusError {
+			t.Errorf("statuses not preserved: %+v", got)
+		}
+	})
+}
+
 func TestCronResumeHandler(t *testing.T) {
 	t.Run("resumes a suspended job and triggers reload", func(t *testing.T) {
 		dir := t.TempDir()

--- a/pkg/daemon/cron_test.go
+++ b/pkg/daemon/cron_test.go
@@ -1,0 +1,213 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ludusrusso/wildgecu/pkg/cron"
+)
+
+type stubReloader struct {
+	calls int
+	err   error
+}
+
+func (s *stubReloader) Reload(_ context.Context) error {
+	s.calls++
+	return s.err
+}
+
+func writeJob(t *testing.T, dir, name, body string) string {
+	t.Helper()
+	path := filepath.Join(dir, cron.Filename(name))
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write job: %v", err)
+	}
+	return path
+}
+
+func TestCronSuspendHandler(t *testing.T) {
+	t.Run("suspends a running job and triggers reload", func(t *testing.T) {
+		dir := t.TempDir()
+		path := writeJob(t, dir, "foo", "---\nname: foo\ncron: \"0 9 * * *\"\n---\nprompt\n")
+		reloader := &stubReloader{}
+		h := cronSuspendHandler(context.Background(), dir, reloader)
+
+		resp, err := h(&Request{Args: map[string]any{"name": "foo"}})
+		if err != nil {
+			t.Fatalf("handler error: %v", err)
+		}
+		if !resp.OK {
+			t.Fatalf("expected OK, got error: %s", resp.Error)
+		}
+		if reloader.calls != 1 {
+			t.Errorf("expected 1 reload, got %d", reloader.calls)
+		}
+		data, _ := os.ReadFile(path)
+		job, err := cron.Parse(data)
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		if !job.Suspended {
+			t.Errorf("expected file to be suspended after handler")
+		}
+	})
+
+	t.Run("no-op when already suspended", func(t *testing.T) {
+		dir := t.TempDir()
+		writeJob(t, dir, "foo", "---\nname: foo\ncron: \"0 9 * * *\"\nsuspended: true\n---\nprompt\n")
+		reloader := &stubReloader{}
+		h := cronSuspendHandler(context.Background(), dir, reloader)
+
+		resp, err := h(&Request{Args: map[string]any{"name": "foo"}})
+		if err != nil {
+			t.Fatalf("handler error: %v", err)
+		}
+		if !resp.OK {
+			t.Fatalf("expected OK no-op, got error: %s", resp.Error)
+		}
+		msg, _ := resp.Payload.(string)
+		if !strings.Contains(msg, "already suspended") {
+			t.Errorf("expected 'already suspended' message, got %q", msg)
+		}
+		if reloader.calls != 0 {
+			t.Errorf("expected no reload on no-op, got %d", reloader.calls)
+		}
+	})
+
+	t.Run("unknown name returns error", func(t *testing.T) {
+		dir := t.TempDir()
+		reloader := &stubReloader{}
+		h := cronSuspendHandler(context.Background(), dir, reloader)
+
+		resp, _ := h(&Request{Args: map[string]any{"name": "ghost"}})
+		if resp.OK {
+			t.Fatalf("expected error for unknown name")
+		}
+		if !strings.Contains(resp.Error, "no job named") {
+			t.Errorf("expected 'no job named' error, got %q", resp.Error)
+		}
+	})
+
+	t.Run("broken config refuses", func(t *testing.T) {
+		dir := t.TempDir()
+		writeJob(t, dir, "broken", "---\nname: broken\n---\nno schedule\n")
+		reloader := &stubReloader{}
+		h := cronSuspendHandler(context.Background(), dir, reloader)
+
+		resp, _ := h(&Request{Args: map[string]any{"name": "broken"}})
+		if resp.OK {
+			t.Fatalf("expected error for broken config")
+		}
+		if !strings.Contains(resp.Error, "config errors") {
+			t.Errorf("expected 'config errors' message, got %q", resp.Error)
+		}
+	})
+
+	t.Run("missing name argument", func(t *testing.T) {
+		dir := t.TempDir()
+		h := cronSuspendHandler(context.Background(), dir, &stubReloader{})
+
+		resp, _ := h(&Request{Args: map[string]any{}})
+		if resp.OK {
+			t.Fatal("expected error for missing name")
+		}
+	})
+
+	t.Run("reload failure propagates", func(t *testing.T) {
+		dir := t.TempDir()
+		writeJob(t, dir, "foo", "---\nname: foo\ncron: \"0 9 * * *\"\n---\nprompt\n")
+		reloader := &stubReloader{err: errors.New("boom")}
+		h := cronSuspendHandler(context.Background(), dir, reloader)
+
+		resp, _ := h(&Request{Args: map[string]any{"name": "foo"}})
+		if resp.OK {
+			t.Fatal("expected reload error to surface")
+		}
+		if !strings.Contains(resp.Error, "boom") {
+			t.Errorf("expected error to include reason, got %q", resp.Error)
+		}
+	})
+}
+
+func TestCronResumeHandler(t *testing.T) {
+	t.Run("resumes a suspended job and triggers reload", func(t *testing.T) {
+		dir := t.TempDir()
+		path := writeJob(t, dir, "foo", "---\nname: foo\ncron: \"0 9 * * *\"\nsuspended: true\n---\nprompt\n")
+		reloader := &stubReloader{}
+		h := cronResumeHandler(context.Background(), dir, reloader)
+
+		resp, err := h(&Request{Args: map[string]any{"name": "foo"}})
+		if err != nil {
+			t.Fatalf("handler error: %v", err)
+		}
+		if !resp.OK {
+			t.Fatalf("expected OK, got error: %s", resp.Error)
+		}
+		if reloader.calls != 1 {
+			t.Errorf("expected 1 reload, got %d", reloader.calls)
+		}
+		data, _ := os.ReadFile(path)
+		job, err := cron.Parse(data)
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		if job.Suspended {
+			t.Errorf("expected file to be resumed after handler")
+		}
+	})
+
+	t.Run("no-op when already running", func(t *testing.T) {
+		dir := t.TempDir()
+		writeJob(t, dir, "foo", "---\nname: foo\ncron: \"0 9 * * *\"\n---\nprompt\n")
+		reloader := &stubReloader{}
+		h := cronResumeHandler(context.Background(), dir, reloader)
+
+		resp, err := h(&Request{Args: map[string]any{"name": "foo"}})
+		if err != nil {
+			t.Fatalf("handler error: %v", err)
+		}
+		if !resp.OK {
+			t.Fatalf("expected OK no-op, got error: %s", resp.Error)
+		}
+		msg, _ := resp.Payload.(string)
+		if !strings.Contains(msg, "already running") {
+			t.Errorf("expected 'already running' message, got %q", msg)
+		}
+		if reloader.calls != 0 {
+			t.Errorf("expected no reload on no-op, got %d", reloader.calls)
+		}
+	})
+
+	t.Run("unknown name returns error", func(t *testing.T) {
+		dir := t.TempDir()
+		h := cronResumeHandler(context.Background(), dir, &stubReloader{})
+
+		resp, _ := h(&Request{Args: map[string]any{"name": "ghost"}})
+		if resp.OK {
+			t.Fatal("expected error for unknown name")
+		}
+		if !strings.Contains(resp.Error, "no job named") {
+			t.Errorf("expected 'no job named' error, got %q", resp.Error)
+		}
+	})
+
+	t.Run("broken config refuses", func(t *testing.T) {
+		dir := t.TempDir()
+		writeJob(t, dir, "broken", "---\nname: broken\n---\n")
+		reloader := &stubReloader{}
+		h := cronResumeHandler(context.Background(), dir, reloader)
+
+		resp, _ := h(&Request{Args: map[string]any{"name": "broken"}})
+		if resp.OK {
+			t.Fatal("expected error for broken config")
+		}
+		if !strings.Contains(resp.Error, "config errors") {
+			t.Errorf("expected 'config errors' message, got %q", resp.Error)
+		}
+	})
+}

--- a/pkg/daemon/cron_test_handler.go
+++ b/pkg/daemon/cron_test_handler.go
@@ -1,0 +1,109 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/ludusrusso/wildgecu/pkg/cron"
+)
+
+// CronTestRequest is the first message on a cron-test streaming connection.
+type CronTestRequest struct {
+	Type    string `json:"type"` // "cron.test"
+	Name    string `json:"name"`
+	Timeout string `json:"timeout,omitempty"` // Go duration string; empty = use job default
+}
+
+// CronTestEvent is a server→client message on a cron-test streaming connection.
+// The event sequence is: zero or more stdout/stderr events followed by one
+// terminal done event carrying the exit code.
+type CronTestEvent struct {
+	Type     string `json:"type"` // "stdout" | "stderr" | "done"
+	Data     string `json:"data,omitempty"`
+	ExitCode int    `json:"exit_code,omitempty"`
+	Duration string `json:"duration,omitempty"`
+	Error    string `json:"error,omitempty"`
+}
+
+// Reserved exit codes surfaced to the CLI.
+const (
+	cronTestExitNoJob       = 126
+	cronTestExitDaemonError = 125
+)
+
+// cronTestRunner executes a job manually and returns its outcome. Kept as an
+// interface so tests can swap in a stub without touching the real scheduler.
+type cronTestRunner func(ctx context.Context, job *cron.CronJob, opts cron.TestOptions) cron.TestResult
+
+// handleCronTestConn runs a single cron-test streaming request on an accepted
+// socket connection. It loads the job from disk, invokes the runner, and
+// emits NDJSON events terminated by a "done" event. The daemon context is
+// used so that a disconnecting client does not cancel an in-flight job.
+func handleCronTestConn(ctx context.Context, conn io.Writer, raw json.RawMessage, cronsDir string, run cronTestRunner, logger *slog.Logger) {
+	var encMu sync.Mutex
+	encoder := json.NewEncoder(conn)
+	send := func(ev CronTestEvent) {
+		encMu.Lock()
+		defer encMu.Unlock()
+		if err := encoder.Encode(ev); err != nil {
+			logger.Debug("cron-test send error (client likely detached)", "error", err)
+		}
+	}
+
+	var req CronTestRequest
+	if err := json.Unmarshal(raw, &req); err != nil {
+		send(CronTestEvent{Type: "done", ExitCode: cronTestExitDaemonError, Error: fmt.Sprintf("bad request: %v", err)})
+		return
+	}
+	if req.Name == "" {
+		send(CronTestEvent{Type: "done", ExitCode: cronTestExitNoJob, Error: "missing name"})
+		return
+	}
+
+	path := filepath.Join(cronsDir, cron.Filename(req.Name))
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		send(CronTestEvent{Type: "done", ExitCode: cronTestExitNoJob, Error: fmt.Sprintf("no job named %q", req.Name)})
+		return
+	}
+	if err != nil {
+		send(CronTestEvent{Type: "done", ExitCode: cronTestExitNoJob, Error: fmt.Sprintf("read %s: %v", req.Name, err)})
+		return
+	}
+	job, err := cron.Parse(data)
+	if err != nil {
+		send(CronTestEvent{Type: "done", ExitCode: cronTestExitNoJob, Error: fmt.Sprintf("job %q has config errors: %v", req.Name, err)})
+		return
+	}
+
+	var override time.Duration
+	if req.Timeout != "" {
+		d, perr := time.ParseDuration(req.Timeout)
+		if perr != nil {
+			send(CronTestEvent{Type: "done", ExitCode: cronTestExitDaemonError, Error: fmt.Sprintf("bad timeout %q: %v", req.Timeout, perr)})
+			return
+		}
+		if d < 0 {
+			send(CronTestEvent{Type: "done", ExitCode: cronTestExitDaemonError, Error: fmt.Sprintf("timeout must be non-negative, got %q", req.Timeout)})
+			return
+		}
+		override = d
+	}
+
+	opts := cron.TestOptions{
+		OnStdout: func(s string) { send(CronTestEvent{Type: "stdout", Data: s}) },
+		OnStderr: func(s string) { send(CronTestEvent{Type: "stderr", Data: s}) },
+		Timeout:  override,
+	}
+
+	res := run(ctx, job, opts)
+	send(CronTestEvent{Type: "done", ExitCode: res.ExitCode, Duration: res.Duration.String()})
+}

--- a/pkg/daemon/cron_test_handler_test.go
+++ b/pkg/daemon/cron_test_handler_test.go
@@ -1,0 +1,169 @@
+package daemon
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ludusrusso/wildgecu/pkg/cron"
+)
+
+func decodeEvents(t *testing.T, buf *bytes.Buffer) []CronTestEvent {
+	t.Helper()
+	var events []CronTestEvent
+	dec := json.NewDecoder(buf)
+	for dec.More() {
+		var ev CronTestEvent
+		if err := dec.Decode(&ev); err != nil {
+			t.Fatalf("decode event: %v", err)
+		}
+		events = append(events, ev)
+	}
+	return events
+}
+
+func runHandler(t *testing.T, dir string, req CronTestRequest, runner cronTestRunner) []CronTestEvent {
+	t.Helper()
+	raw, _ := json.Marshal(req)
+	var buf bytes.Buffer
+	handleCronTestConn(context.Background(), &buf, raw, dir, runner, slog.Default())
+	return decodeEvents(t, &buf)
+}
+
+func TestCronTestHandler(t *testing.T) {
+	validJob := "---\nname: foo\ncron: \"0 9 * * *\"\n---\nhello"
+
+	t.Run("emits stdout then done with exit code 0", func(t *testing.T) {
+		dir := t.TempDir()
+		os.WriteFile(filepath.Join(dir, cron.Filename("foo")), []byte(validJob), 0o644)
+
+		runner := func(_ context.Context, _ *cron.CronJob, opts cron.TestOptions) cron.TestResult {
+			opts.OnStdout("hi from run")
+			return cron.TestResult{ExitCode: 0, Duration: 123 * time.Millisecond}
+		}
+
+		events := runHandler(t, dir, CronTestRequest{Type: "cron.test", Name: "foo"}, runner)
+
+		if len(events) != 2 {
+			t.Fatalf("expected 2 events, got %d: %+v", len(events), events)
+		}
+		if events[0].Type != "stdout" || events[0].Data != "hi from run" {
+			t.Errorf("unexpected first event: %+v", events[0])
+		}
+		if events[1].Type != "done" || events[1].ExitCode != 0 {
+			t.Errorf("unexpected done event: %+v", events[1])
+		}
+		if events[1].Duration == "" {
+			t.Errorf("expected non-empty duration")
+		}
+	})
+
+	t.Run("unknown job returns exit 126", func(t *testing.T) {
+		events := runHandler(t, t.TempDir(), CronTestRequest{Type: "cron.test", Name: "ghost"}, nil)
+		if len(events) != 1 || events[0].Type != "done" {
+			t.Fatalf("expected single done event, got %+v", events)
+		}
+		if events[0].ExitCode != cronTestExitNoJob {
+			t.Errorf("expected exit 126, got %d", events[0].ExitCode)
+		}
+		if !strings.Contains(events[0].Error, "no job named") {
+			t.Errorf("expected 'no job named' error, got %q", events[0].Error)
+		}
+	})
+
+	t.Run("broken config returns exit 126", func(t *testing.T) {
+		dir := t.TempDir()
+		os.WriteFile(filepath.Join(dir, cron.Filename("broken")), []byte("---\nname: broken\n---\nno schedule"), 0o644)
+
+		events := runHandler(t, dir, CronTestRequest{Type: "cron.test", Name: "broken"}, nil)
+		if len(events) != 1 || events[0].ExitCode != cronTestExitNoJob {
+			t.Fatalf("expected exit 126 done event, got %+v", events)
+		}
+		if !strings.Contains(events[0].Error, "config errors") {
+			t.Errorf("expected 'config errors' in error, got %q", events[0].Error)
+		}
+	})
+
+	t.Run("runner exit code is propagated", func(t *testing.T) {
+		dir := t.TempDir()
+		os.WriteFile(filepath.Join(dir, cron.Filename("foo")), []byte(validJob), 0o644)
+
+		runner := func(_ context.Context, _ *cron.CronJob, _ cron.TestOptions) cron.TestResult {
+			return cron.TestResult{ExitCode: 7, Duration: time.Second}
+		}
+
+		events := runHandler(t, dir, CronTestRequest{Type: "cron.test", Name: "foo"}, runner)
+		if events[len(events)-1].ExitCode != 7 {
+			t.Errorf("expected exit 7, got %d", events[len(events)-1].ExitCode)
+		}
+	})
+
+	t.Run("timeout override parsed and forwarded to runner", func(t *testing.T) {
+		dir := t.TempDir()
+		os.WriteFile(filepath.Join(dir, cron.Filename("foo")), []byte(validJob), 0o644)
+
+		var gotTimeout time.Duration
+		runner := func(_ context.Context, _ *cron.CronJob, opts cron.TestOptions) cron.TestResult {
+			gotTimeout = opts.Timeout
+			return cron.TestResult{}
+		}
+
+		runHandler(t, dir, CronTestRequest{Type: "cron.test", Name: "foo", Timeout: "45s"}, runner)
+		if gotTimeout != 45*time.Second {
+			t.Errorf("expected 45s override, got %s", gotTimeout)
+		}
+	})
+
+	t.Run("invalid timeout is rejected with daemon error", func(t *testing.T) {
+		dir := t.TempDir()
+		os.WriteFile(filepath.Join(dir, cron.Filename("foo")), []byte(validJob), 0o644)
+
+		called := false
+		runner := func(_ context.Context, _ *cron.CronJob, _ cron.TestOptions) cron.TestResult {
+			called = true
+			return cron.TestResult{}
+		}
+
+		events := runHandler(t, dir, CronTestRequest{Type: "cron.test", Name: "foo", Timeout: "not-a-duration"}, runner)
+		if called {
+			t.Errorf("runner should not be called for invalid timeout")
+		}
+		if events[0].ExitCode != cronTestExitDaemonError {
+			t.Errorf("expected exit 125, got %d", events[0].ExitCode)
+		}
+	})
+
+	t.Run("missing name returns exit 126", func(t *testing.T) {
+		events := runHandler(t, t.TempDir(), CronTestRequest{Type: "cron.test"}, nil)
+		if events[0].ExitCode != cronTestExitNoJob {
+			t.Errorf("expected exit 126, got %d", events[0].ExitCode)
+		}
+	})
+}
+
+// TestCronTestHandlerPropagatesStderr covers that both streaming callbacks
+// reach the client before the done event.
+func TestCronTestHandlerPropagatesStderr(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, cron.Filename("foo")), []byte("---\nname: foo\ncron: \"0 9 * * *\"\n---\nx"), 0o644)
+
+	runner := func(_ context.Context, _ *cron.CronJob, opts cron.TestOptions) cron.TestResult {
+		opts.OnStderr("oh no")
+		return cron.TestResult{ExitCode: 1}
+	}
+
+	events := runHandler(t, dir, CronTestRequest{Type: "cron.test", Name: "foo"}, runner)
+	if events[0].Type != "stderr" || events[0].Data != "oh no" {
+		t.Errorf("expected stderr event first, got %+v", events[0])
+	}
+	if events[len(events)-1].Type != "done" || events[len(events)-1].ExitCode != 1 {
+		t.Errorf("expected done with exit 1, got %+v", events[len(events)-1])
+	}
+}
+

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -221,6 +221,7 @@ func Run(ctx context.Context, cfg Config) error {
 		})
 		srv.Handle("cron-suspend", cronSuspendHandler(ctx, h.CronsDir(), scheduler))
 		srv.Handle("cron-resume", cronResumeHandler(ctx, h.CronsDir(), scheduler))
+		srv.Handle("cron-list", cronListHandler(scheduler))
 	} else {
 		logger.Info("cron scheduler disabled (no provider configured)")
 	}

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -219,6 +219,8 @@ func Run(ctx context.Context, cfg Config) error {
 			}
 			return &Response{OK: true, Payload: "cron jobs reloaded"}, nil
 		})
+		srv.Handle("cron-suspend", cronSuspendHandler(ctx, h.CronsDir(), scheduler))
+		srv.Handle("cron-resume", cronResumeHandler(ctx, h.CronsDir(), scheduler))
 	} else {
 		logger.Info("cron scheduler disabled (no provider configured)")
 	}

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -2,8 +2,10 @@ package daemon
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
+	"net"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -222,6 +224,15 @@ func Run(ctx context.Context, cfg Config) error {
 		srv.Handle("cron-suspend", cronSuspendHandler(ctx, h.CronsDir(), scheduler))
 		srv.Handle("cron-resume", cronResumeHandler(ctx, h.CronsDir(), scheduler))
 		srv.Handle("cron-list", cronListHandler(scheduler))
+
+		cronsDir := h.CronsDir()
+		runner := func(runCtx context.Context, job *cron.CronJob, opts cron.TestOptions) cron.TestResult {
+			return cron.ExecuteTest(runCtx, execCfg, job, opts)
+		}
+		srv.HandleStreaming("cron.test", func(conn net.Conn, raw json.RawMessage) {
+			defer conn.Close()
+			handleCronTestConn(ctx, conn, raw, cronsDir, runner, logger)
+		})
 	} else {
 		logger.Info("cron scheduler disabled (no provider configured)")
 	}

--- a/pkg/daemon/socket.go
+++ b/pkg/daemon/socket.go
@@ -16,16 +16,23 @@ import (
 // CommandHandler processes a daemon request and returns a response.
 type CommandHandler func(*Request) (*Response, error)
 
+// StreamingHandler takes ownership of an accepted connection plus the first
+// JSON message that was consumed for protocol detection. It is responsible
+// for all subsequent reads and writes until it returns. Used for long-lived
+// NDJSON flows that don't fit the single-request CommandHandler shape.
+type StreamingHandler func(conn net.Conn, raw json.RawMessage)
+
 // SocketServer listens on a Unix domain socket and dispatches commands.
 type SocketServer struct {
-	listener net.Listener
-	handlers map[string]CommandHandler
-	sessions *SessionManager
-	commands *command.Registry
-	logger   *slog.Logger
-	path     string
-	ctx      context.Context
-	wg       sync.WaitGroup
+	listener  net.Listener
+	handlers  map[string]CommandHandler
+	streaming map[string]StreamingHandler
+	sessions  *SessionManager
+	commands  *command.Registry
+	logger    *slog.Logger
+	path      string
+	ctx       context.Context
+	wg        sync.WaitGroup
 }
 
 // NewSocketServer creates and starts listening on the Unix socket.
@@ -48,10 +55,11 @@ func NewSocketServer(logger *slog.Logger) (*SocketServer, error) {
 	}
 
 	return &SocketServer{
-		path:     path,
-		listener: ln,
-		handlers: make(map[string]CommandHandler),
-		logger:   logger,
+		path:      path,
+		listener:  ln,
+		handlers:  make(map[string]CommandHandler),
+		streaming: make(map[string]StreamingHandler),
+		logger:    logger,
 	}, nil
 }
 
@@ -68,6 +76,13 @@ func (s *SocketServer) SetCommands(r *command.Registry) {
 // Handle registers a handler for the given command name.
 func (s *SocketServer) Handle(cmd string, h CommandHandler) {
 	s.handlers[cmd] = h
+}
+
+// HandleStreaming registers a streaming handler keyed by the first JSON
+// message's "type" field. When the dispatcher sees that type it hands the
+// connection off to h.
+func (s *SocketServer) HandleStreaming(t string, h StreamingHandler) {
+	s.streaming[t] = h
 }
 
 // Serve accepts connections until ctx is cancelled.
@@ -125,6 +140,11 @@ func (s *SocketServer) handleConnection(_ context.Context, conn net.Conn) {
 	}
 	if err := json.Unmarshal(raw, &probe); err != nil {
 		s.logger.Error("unmarshal probe", "error", err)
+		return
+	}
+
+	if h, ok := s.streaming[probe.Type]; ok {
+		h(conn, raw)
 		return
 	}
 


### PR DESCRIPTION
## Summary

Implements PRD #63: Suspend/resume and manual test runs for cron jobs

## Resolved sub-issues

- #68 cron test: manual run with streaming output
- #67 Timeout frontmatter field + TIMEOUT column + scheduled-run enforcement
- #66 Daemon-backed cron ls with STATUS column and error tracking
- #65 cron suspend / cron resume CLI + format-preserving frontmatter writer
- #64 Suspended frontmatter field + cron reload CLI command

Closes #63