### PR TITLE
docs(readme): add development setup section

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,25 @@ Build with a version tag:
 go build -ldflags "-X wildgecu/cmd.Version=1.0.0" -o wildgecu .
 ```
 
+## Development
+
+To run `make lint` and `make test` you need the toolchain versions pinned in `.mise.toml` (Go and `golangci-lint`). The repository uses [mise](https://mise.jdx.dev) to manage them.
+
+1. Install `mise` following the [official instructions](https://mise.jdx.dev/getting-started.html).
+2. From the repository root, authorize the config file:
+
+   ```bash
+   mise trust
+   ```
+
+3. Install the pinned tools:
+
+   ```bash
+   mise install
+   ```
+
+After that, `make lint` and `make test` work out of the box.
+
 ## Cron jobs
 
 The daemon executes scheduled LLM prompts. Cron jobs are defined as markdown files with YAML frontmatter in `~/.wildgecu/crons/`. Results are written to `~/.wildgecu/cron-results/`.


### PR DESCRIPTION
## Summary

Add a "Development" section to the README that documents how to prepare the local toolchain before running `make lint` or `make test`.

The repository already pins Go and `golangci-lint` versions via `.mise.toml`, but the README does not mention it. Contributors who clone the repo and try `make lint` hit a `mise: command not found` error or a `Config files ... are not trusted` error, with no guidance in the project docs.

The new section explains, in three steps:

1. install [mise](https://mise.jdx.dev),
2. run `mise trust` from the repository root to authorize `.mise.toml`,
3. run `mise install` to install the pinned versions.

After that, `make lint` and `make test` work out of the box.

## Scope

Documentation only. No changes to the `Makefile`, `.mise.toml`, or CI workflows.